### PR TITLE
Remove residentmobileapp context path as part of the mimoto urls

### DIFF
--- a/inji-web/src/utils/config.js
+++ b/inji-web/src/utils/config.js
@@ -16,11 +16,11 @@ export const getESignetRedirectURL = (scope, clientId, codeChallenge, state) => 
 
 /* MIMOTO CONFIG */
 export const MIMOTO_URL = process.env.REACT_APP_MIMOTO_URL || "/mimoto";
-export const FETCH_ISSUERS_URL = `${MIMOTO_URL}/residentmobileapp/v2/issuers`;
-export const getSearchIssuersUrl = (issuer) => `${MIMOTO_URL}/residentmobileapp/v2/issuers?search=${issuer}`;
-export const getCredentialsSupportedUrl = (issuerId) => `${MIMOTO_URL}/residentmobileapp/v2/issuers/${issuerId}/credentials-supported`;
-export const getFetchAccessTokenFromCodeApi = (issuer) => `${MIMOTO_URL}/residentmobileapp/get-token/${issuer}`;
-export const getVcDownloadAPI = (issuerId, credentialId) => `${MIMOTO_URL}/residentmobileapp/v2/issuers/${issuerId}/credentials/${credentialId}/download`;
+export const FETCH_ISSUERS_URL = `${MIMOTO_URL}/v2/issuers`;
+export const getSearchIssuersUrl = (issuer) => `${MIMOTO_URL}/v2/issuers?search=${issuer}`;
+export const getCredentialsSupportedUrl = (issuerId) => `${MIMOTO_URL}/v2/issuers/${issuerId}/credentials-supported`;
+export const getFetchAccessTokenFromCodeApi = (issuer) => `${MIMOTO_URL}/get-token/${issuer}`;
+export const getVcDownloadAPI = (issuerId, credentialId) => `${MIMOTO_URL}/v2/issuers/${issuerId}/credentials/${credentialId}/download`;
 
 /* MISC */
 export const DATA_KEY_IN_LOCAL_STORAGE = "vcDownloadDetails";


### PR DESCRIPTION
The context path can be passed as part of the env variable value for REACT_MIMOTO_URL(Eg: https://inji.dev1.mosip.net/v1/mimoto where /v1/mimoto is the context path configured in the mimoto backend).
Taking it from the env allows the context path to be configurable.