### PR TITLE
Update mimoto urls

### DIFF
--- a/inji-web/src/errors/CustomError.js
+++ b/inji-web/src/errors/CustomError.js
@@ -1,0 +1,6 @@
+export class CustomError extends Error {
+    constructor(message, details) {
+        super(message);
+        this.details = details;
+    }
+}

--- a/inji-web/src/pages/Certificate/index.js
+++ b/inji-web/src/pages/Certificate/index.js
@@ -70,20 +70,6 @@ const DisplayComponent = ({message, inProgress}) => {
     const {issuerId} = useParams();
     const issuerDisplayName = useLocation().state?.issuerDisplayName;
     switch (message) {
-        case 'Invalid user credentials':
-        case 'Failed to verify the user credentials':
-        case 'Failed to download the credentials':
-            return (<>
-                <Grid item xs={12}>
-                    <ErrorComponent/>
-                </Grid>
-                <Grid item xs={12}>
-                    <Typography variant='h6' style={{margin: '12px auto'}}>{message}</Typography>
-                </Grid>
-                <Grid item xs={12}>
-                    <ResultBackButton issuerId={issuerId} issuerDisplayName={issuerDisplayName}/>
-                </Grid>
-            </>);
         case 'Verifying credentials':
         case 'Downloading credentials':
             return (
@@ -113,6 +99,22 @@ const DisplayComponent = ({message, inProgress}) => {
                     </Grid>
                 </>
             );
+        case 'Invalid user credentials':
+        case 'Failed to verify the user credentials':
+        case 'Failed to download the credentials':
+        default:
+            return (<>
+                <Grid item xs={12}>
+                    <ErrorComponent/>
+                </Grid>
+                <Grid item xs={12}>
+                    <Typography variant='h6' style={{margin: '12px auto'}}>{message}</Typography>
+                </Grid>
+                <Grid item xs={12}>
+                    <ResultBackButton issuerId={issuerId} issuerDisplayName={issuerDisplayName}/>
+                </Grid>
+            </>);
+
     }
 }
 

--- a/inji-web/src/pages/Certificate/index.js
+++ b/inji-web/src/pages/Certificate/index.js
@@ -19,6 +19,11 @@ const getCodeVerifierAndClientId = () => {
     return {clientId, codeVerifier};
 }
 
+const getDownloadErrorMessage = (error) => {
+    if (!error || !error.data || !error.data.errors) return 'Failed to download the credentials';
+    return error.data.errors[0].errorMessage;
+};
+
 const ErrorComponent = () => {
     return (<ErrorIcon style={{fontSize: '40px', color: 'red', margin: '12px auto'}}/>);
 };
@@ -136,8 +141,8 @@ function Certificate(props) {
                     setProgress(false);
                 })
                 .catch(error => {
-                    console.log(error)
-                    setMessage('Failed to download the credentials');
+                    console.error("Error occurred while downloading the credential. Error message: ", error);
+                    setMessage(getDownloadErrorMessage(error));
                     setProgress(false);
                 });
         })

--- a/inji-web/src/pages/Certificate/index.js
+++ b/inji-web/src/pages/Certificate/index.js
@@ -20,8 +20,8 @@ const getCodeVerifierAndClientId = () => {
 }
 
 const getDownloadErrorMessage = (error) => {
-    if (!error || !error.data || !error.data.errors) return 'Failed to download the credentials';
-    return error.data.errors[0].errorMessage;
+    if (!error?.response?.data?.errors) return 'Failed to download the credentials';
+    return error.response.data.errors[0].errorMessage;
 };
 
 const ErrorComponent = () => {

--- a/inji-web/src/pages/Certificate/index.js
+++ b/inji-web/src/pages/Certificate/index.js
@@ -10,6 +10,7 @@ import Header from "./Header";
 import {fetchAccessToken} from "../../utils/oauth-utils";
 import {downloadCredentials} from "../../utils/misc";
 import {DATA_KEY_IN_LOCAL_STORAGE} from "../../utils/config";
+import {CustomError} from "../../errors/CustomError";
 
 const getCodeVerifierAndClientId = () => {
     let details = JSON.parse(localStorage.getItem(DATA_KEY_IN_LOCAL_STORAGE) || "{}");
@@ -20,8 +21,14 @@ const getCodeVerifierAndClientId = () => {
 }
 
 const getDownloadErrorMessage = (error) => {
-    if (!error?.response?.data?.errors) return 'Failed to download the credentials';
-    return error.response.data.errors[0].errorMessage;
+    try {
+        if (error instanceof CustomError) {
+            let responseErrorObject = JSON.parse(error.details.error);
+            if (responseErrorObject?.errors)
+                return responseErrorObject.errors[0].errorMessage;
+        }
+    } catch (exception) {}
+    return 'Failed to download the credentials';
 };
 
 const ErrorComponent = () => {

--- a/inji-web/src/utils/config.js
+++ b/inji-web/src/utils/config.js
@@ -20,7 +20,7 @@ export const getESignetRedirectURL = (scope, clientId, codeChallenge, state) => 
 export const MIMOTO_URL = process.env.REACT_APP_MIMOTO_URL || "/v1/mimoto";
 export const FETCH_ISSUERS_URL = `${MIMOTO_URL}/issuers`;
 export const getSearchIssuersUrl = (issuer) => `${MIMOTO_URL}/issuers?search=${issuer}`;
-export const getCredentialsSupportedUrl = (issuerId) => `${MIMOTO_URL}/issuers/${issuerId}/credentials-supported`;
+export const getCredentialsSupportedUrl = (issuerId) => `${MIMOTO_URL}/issuers/${issuerId}/credentialTypes`;
 export const getFetchAccessTokenFromCodeApi = (issuer) => `${MIMOTO_URL}/get-token/${issuer}`;
 export const getVcDownloadAPI = (issuerId, credentialId) => `${MIMOTO_URL}/issuers/${issuerId}/credentials/${credentialId}/download`;
 

--- a/inji-web/src/utils/config.js
+++ b/inji-web/src/utils/config.js
@@ -18,11 +18,11 @@ export const getESignetRedirectURL = (scope, clientId, codeChallenge, state) => 
 
 /* MIMOTO CONFIG */
 export const MIMOTO_URL = process.env.REACT_APP_MIMOTO_URL || "/v1/mimoto";
-export const FETCH_ISSUERS_URL = `${MIMOTO_URL}/v2/issuers`;
-export const getSearchIssuersUrl = (issuer) => `${MIMOTO_URL}/v2/issuers?search=${issuer}`;
-export const getCredentialsSupportedUrl = (issuerId) => `${MIMOTO_URL}/v2/issuers/${issuerId}/credentials-supported`;
+export const FETCH_ISSUERS_URL = `${MIMOTO_URL}/issuers`;
+export const getSearchIssuersUrl = (issuer) => `${MIMOTO_URL}/issuers?search=${issuer}`;
+export const getCredentialsSupportedUrl = (issuerId) => `${MIMOTO_URL}/issuers/${issuerId}/credentials-supported`;
 export const getFetchAccessTokenFromCodeApi = (issuer) => `${MIMOTO_URL}/get-token/${issuer}`;
-export const getVcDownloadAPI = (issuerId, credentialId) => `${MIMOTO_URL}/v2/issuers/${issuerId}/credentials/${credentialId}/download`;
+export const getVcDownloadAPI = (issuerId, credentialId) => `${MIMOTO_URL}/issuers/${issuerId}/credentials/${credentialId}/download`;
 
 /* MISC */
 export const DATA_KEY_IN_LOCAL_STORAGE = "vcDownloadDetails";

--- a/inji-web/src/utils/misc.js
+++ b/inji-web/src/utils/misc.js
@@ -23,7 +23,7 @@ export const getUrlParamsMap = (searchString) => {
 export const getFileName = (contentDispositionHeader) => {
     if (!contentDispositionHeader) return null;
     // sample header value => Content-Disposition: 'attachment; filename="x"' and we need "x"
-    const filenameMatch = contentDispositionHeader.match(/filename="([^"]+)"/);
+    const filenameMatch = contentDispositionHeader.match(/filename=(.*?)(;|$)/);
     if (filenameMatch && filenameMatch.length > 1) {
         return filenameMatch[1];
     }

--- a/inji-web/src/utils/misc.js
+++ b/inji-web/src/utils/misc.js
@@ -1,5 +1,6 @@
 import axios from "axios";
 import {getVcDownloadAPI} from "./config";
+import {CustomError} from "../errors/CustomError";
 
 export const getCertificatesAutoCompleteOptions = (credentialsList) => credentialsList.map(cred => {
     return {label: cred.display[0].name, value: cred.display[0].name}
@@ -31,15 +32,26 @@ export const getFileName = (contentDispositionHeader) => {
 };
 
 export const downloadCredentials = async (issuerId, certificateId, token) => {
-    const response = await axios.get(getVcDownloadAPI(issuerId, certificateId), {
-        headers: {/*
+    let response;
+    try {
+        response = await axios.get(getVcDownloadAPI(issuerId, certificateId), {
+            headers: {/*
             'Authorization': 'Bearer ' + token,*/
-            'Bearer': token,
-            'Cache-Control': 'no-cache, no-store, must-revalidate'
-        },
-        responseType: 'blob' // Set the response type to 'arraybuffer' to receive binary data
-    });
+                'Bearer': token,
+                'Cache-Control': 'no-cache, no-store, must-revalidate'
+            },
+            responseType: 'blob' // Set the response type to 'arraybuffer' to receive binary data
+        });
+    } catch (exception) {
+        response = exception.response;
+    }
+
     const blob = new Blob([response.data], { type: response.headers['content-type'] });
+
+    if (response.status === 500) {
+        let responseObject = await blob.text();
+        throw new CustomError(responseObject, {error: responseObject});
+    }
     let fileName = getFileName(response.headers['content-disposition']) ?? `${certificateId}.pdf`;
 
     // Create a temporary URL for the Blob

--- a/inji-web/src/utils/misc.js
+++ b/inji-web/src/utils/misc.js
@@ -20,6 +20,16 @@ export const getUrlParamsMap = (searchString) => {
     return searchParamsMap;
 }
 
+export const getFileName = (contentDispositionHeader) => {
+    if (!contentDispositionHeader) return null;
+    // sample header value => Content-Disposition: 'attachment; filename="x"' and we need "x"
+    const filenameMatch = contentDispositionHeader.match(/filename="([^"]+)"/);
+    if (filenameMatch && filenameMatch.length > 1) {
+        return filenameMatch[1];
+    }
+    return null;
+};
+
 export const downloadCredentials = async (issuerId, certificateId, token) => {
     const response = await axios.get(getVcDownloadAPI(issuerId, certificateId), {
         headers: {/*
@@ -30,6 +40,7 @@ export const downloadCredentials = async (issuerId, certificateId, token) => {
         responseType: 'blob' // Set the response type to 'arraybuffer' to receive binary data
     });
     const blob = new Blob([response.data], { type: response.headers['content-type'] });
+    let fileName = getFileName(response.headers['content-disposition']) ?? `${certificateId}.pdf`;
 
     // Create a temporary URL for the Blob
     const url = window.URL.createObjectURL(blob);
@@ -39,7 +50,7 @@ export const downloadCredentials = async (issuerId, certificateId, token) => {
     link.href = url;
 
     // Set the filename for download
-    link.setAttribute('download', `${certificateId}.pdf`);
+    link.setAttribute('download', fileName);
     link.setAttribute('target', '_blank'); // Open the link in a new tab or window
 
     // Trigger a click event to download the file


### PR DESCRIPTION
This pr contains following changes:

- Remove v2 from mimoto urls
- Display custom error message as received from backend in case of 500 errors during credential download
- Use file name as received from Content-Disposition header while downloading