### PR TITLE
[INJIWEB-1429] use redux persist library to persist the issuers list

### DIFF
--- a/inji-web/package.json
+++ b/inji-web/package.json
@@ -28,6 +28,7 @@
     "react-scripts": "5.0.1",
     "react-toastify": "^10.0.5",
     "redux": "^5.0.1",
+    "redux-persist": "6.0.0",
     "tailwindcss": "^3.4.3",
     "tailwindcss-rtl": "^0.9.0",
     "typescript": "^4.9.5",

--- a/inji-web/src/index.js
+++ b/inji-web/src/index.js
@@ -1,17 +1,19 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
+import ReactDOM from "react-dom/client";
 import {AppRouter} from "./Router";
-import './index.css';
-import 'react-toastify/dist/ReactToastify.css';
-import '../src/utils/i18n';
+import "./index.css";
+import "react-toastify/dist/ReactToastify.css";
+import "../src/utils/i18n";
 import {Provider} from "react-redux";
-import {reduxStore} from "./redux/reduxStore";
+import {persistor, reduxStore} from "./redux/reduxStore";
 import {AppToaster} from "./components/Common/AppToaster";
+import {PersistGate} from "redux-persist/integration/react";
 
-const root = ReactDOM.createRoot(document.getElementById('root'));
+const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
     <Provider store={reduxStore}>
-        <AppToaster/>
-        <AppRouter/>
+        <PersistGate loading={null} persistor={persistor}>
+            <AppToaster />
+            <AppRouter />
+        </PersistGate>
     </Provider>
 );

--- a/inji-web/src/redux/reducers/issuersReducer.ts
+++ b/inji-web/src/redux/reducers/issuersReducer.ts
@@ -1,5 +1,6 @@
 import {IssuerObject} from "../../types/data";
 import {IssuersReducerActionType} from "../../types/redux";
+import {REHYDRATE} from "redux-persist";
 
 const initialState = {
     issuers: [],
@@ -33,6 +34,15 @@ export const issuersReducer = (state = initialState, action: any) => {
                 ...state,
                 selected_issuer: selectedIssuer
             };
+        case REHYDRATE:
+            if (action.payload?.issuers) {
+                const res = {
+                    ...state,
+                    issuers: action.payload.issuers // Merge persisted state (issuers) into Redux state
+                };
+                return res
+            }
+            return state;
         default:
             return state;
     }

--- a/inji-web/src/redux/reduxStore.ts
+++ b/inji-web/src/redux/reduxStore.ts
@@ -1,12 +1,27 @@
 import {configureStore} from "@reduxjs/toolkit";
+import {persistReducer, persistStore, createTransform} from "redux-persist";
+import storage from "redux-persist/lib/storage"; // Use AsyncStorage for React Native
 import {issuersReducer} from "./reducers/issuersReducer";
 import {credentialsReducer} from "./reducers/credentialsReducer";
 import {commonReducer} from "./reducers/commonReducer";
 
+const issuersPersistConfig = {
+    key: "issuers",
+    storage,
+    whitelist: ["issuers"], //  mention issuers reducer field name (issuers) that needs to be persisted
+};
+
+const persistedIssuersReducer = persistReducer(
+    issuersPersistConfig,
+    issuersReducer
+);
+
 export const reduxStore = configureStore({
     reducer: {
-        issuers: issuersReducer,
+        issuers: persistedIssuersReducer,
         credentials: credentialsReducer,
         common: commonReducer
-    },
-})
+    }
+});
+
+export const persistor = persistStore(reduxStore);


### PR DESCRIPTION
- Currently we are storing the selected issuer details in redux store and using it when user selected a specific issuer to download the VC. When user is navigated to auth server web page and clicks on back button, instead of showing selected issuer credential types it is showing no credentials found. To resolve this we are using redux persist to persist the issuers list.