### PR TITLE
[INJIWEB-1637] fix: redirect to passcode if session active on root page

### DIFF
--- a/inji-web/src/__tests__/components/LoginSessionStatusChecker.test.tsx
+++ b/inji-web/src/__tests__/components/LoginSessionStatusChecker.test.tsx
@@ -36,24 +36,24 @@ describe('LoginSessionStatusChecker', () => {
         });
     });
 
-    const excludedKeys = ['USER_RESET_PASSCODE', 'PASSCODE', 'USER_ISSUER', 'ISSUER'];
-    const nonPasscodeRelatedRoutes = Object.entries(ROUTES)
-        .filter(([key]) => !excludedKeys.includes(key))
+    const excludedKeys = ['USER_RESET_PASSCODE', 'USER_PASSCODE', 'USER_ISSUER', 'ISSUER'];
+    const nonPasscodeRelatedProtectedRoutes = Object.entries(ROUTES)
+        .filter(([key]) => !excludedKeys.includes(key) && key.startsWith('USER'))
         .map(([_, value]) => value);
-    nonPasscodeRelatedRoutes.push(ROUTES.USER_ISSUER("issuer1"), ROUTES.ISSUER("issuer1"));
+    nonPasscodeRelatedProtectedRoutes.push(ROUTES.USER_ISSUER("issuer1"), ROUTES.ISSUER("issuer1"));
 
-    test.each(nonPasscodeRelatedRoutes)('should redirect to passcode page when session is active but no wallet ID for path %s', async (route) => {
+    test.each(nonPasscodeRelatedProtectedRoutes)('should redirect to passcode page when session is active but no wallet ID for path %s', async (route) => {
         (useLocation as jest.Mock).mockReturnValue({pathname: route});
         setupMockActiveSessionInStorage()
 
         render(<LoginSessionStatusChecker/>);
 
         await waitFor(() =>
-            expect(mockNavigate).toHaveBeenCalledWith(ROUTES.PASSCODE)
+            expect(mockNavigate).toHaveBeenCalledWith(ROUTES.USER_PASSCODE)
         )
     });
 
-    const passcodeRelatedRoutes = [ROUTES.PASSCODE, ROUTES.USER_RESET_PASSCODE];
+    const passcodeRelatedRoutes = [ROUTES.USER_PASSCODE, ROUTES.USER_RESET_PASSCODE];
     test.each(passcodeRelatedRoutes)('should not redirect to login when accessing passcode related route - %s with active session', (route) => {
         (useLocation as jest.Mock).mockReturnValue({pathname: route});
         setupMockActiveSessionInStorage();
@@ -61,7 +61,7 @@ describe('LoginSessionStatusChecker', () => {
         render(<LoginSessionStatusChecker/>);
 
         expect(mockNavigate).not.toHaveBeenCalled();
-        expect(mockNavigate).not.toHaveBeenCalledWith(ROUTES.PASSCODE);
+        expect(mockNavigate).not.toHaveBeenCalledWith(ROUTES.USER_PASSCODE);
     })
 
     test('should redirect to login (root page) when accessing protected route without being logged in', async () => {

--- a/inji-web/src/__tests__/hooks/useInterceptor.test.ts
+++ b/inji-web/src/__tests__/hooks/useInterceptor.test.ts
@@ -137,7 +137,7 @@ describe("useInterceptor", () => {
         assertStoringOfCurrentLocation()
     })
 
-    test.each([ROUTES.PASSCODE, ROUTES.USER_RESET_PASSCODE])('should redirect to login when accessing protected API in passcode related page - %s and response is unauthorized', async (route) => {
+    test.each([ROUTES.USER_PASSCODE, ROUTES.USER_RESET_PASSCODE])('should redirect to login when accessing protected API in passcode related page - %s and response is unauthorized', async (route) => {
         (useLocation as jest.Mock).mockReturnValue({
             pathname: route,
             search: null,

--- a/inji-web/src/components/Common/LoginSessionStatusChecker.ts
+++ b/inji-web/src/components/Common/LoginSessionStatusChecker.ts
@@ -35,7 +35,7 @@ const LoginSessionStatusChecker = () => {
         const isSessionActive: boolean = !!user
         const walletId = AppStorage.getItem(KEYS.WALLET_ID);
         const isLoggedIn = !!walletId && isSessionActive;
-        const isPasscodeRelatedRoute = location.pathname === ROUTES.USER_RESET_PASSCODE || location.pathname === ROUTES.PASSCODE;
+        const isPasscodeRelatedRoute = location.pathname === ROUTES.USER_RESET_PASSCODE || location.pathname === ROUTES.USER_PASSCODE;
 
         /**
          * If user is not logged in, ask them to login again or unlock wallet based on the session state.
@@ -48,7 +48,7 @@ const LoginSessionStatusChecker = () => {
             }
             // Session active but wallet locked - redirect to passcode
             console.warn('Session active but wallet locked, redirecting to passcode page');
-            navigate(ROUTES.PASSCODE);
+            navigate(ROUTES.USER_PASSCODE);
         }
         // Trying to access a login protected route without being logged in
         else if (!isLoggedIn && isLoginProtectedRoute(location.pathname)) {

--- a/inji-web/src/components/Common/LoginSessionStatusChecker.ts
+++ b/inji-web/src/components/Common/LoginSessionStatusChecker.ts
@@ -25,7 +25,7 @@ const LoginSessionStatusChecker = () => {
     const redirectToLogin = useCallback(() => {
         removeUser()
         if (location.pathname !== ROUTES.ROOT) {
-            console.warn("Redirecting to / page as accessing protected route without login from ",location.pathname);
+            console.warn("Redirecting to / page as accessing protected route without login from ", location.pathname);
             navigate(ROUTES.ROOT)
         }
     }, [location.pathname, navigate, removeUser]);
@@ -40,21 +40,20 @@ const LoginSessionStatusChecker = () => {
         /**
          * If user is not logged in, ask them to login again or unlock wallet based on the session state.
          */
-        if (!isLoggedIn && isLoginProtectedRoute(location.pathname)) {
+        // Redirect based on session state
+        if (isSessionActive) {
             // User can stay on passcode routes if session is active
-            if (isPasscodeRelatedRoute && isSessionActive) {
+            if (isPasscodeRelatedRoute) {
                 return;
             }
-
-            // Redirect based on session state
-            if (isSessionActive) {
-                // Session active but wallet locked - redirect to passcode
-                console.warn('Session active but wallet locked, redirecting to passcode page');
-                navigate(ROUTES.PASSCODE);
-            } else {
-                // No active session - clear user data and redirect to log in
-                redirectToLogin()
-            }
+            // Session active but wallet locked - redirect to passcode
+            console.warn('Session active but wallet locked, redirecting to passcode page');
+            navigate(ROUTES.PASSCODE);
+        }
+        // Trying to access a login protected route without being logged in
+        else if (!isLoggedIn && isLoginProtectedRoute(location.pathname)) {
+            // No active session - clear user data and redirect to log in
+            redirectToLogin()
         }
     }, [navigate, location.pathname, redirectToLogin]);
 

--- a/inji-web/src/components/Common/LoginSessionStatusChecker.ts
+++ b/inji-web/src/components/Common/LoginSessionStatusChecker.ts
@@ -22,13 +22,16 @@ const LoginSessionStatusChecker = () => {
     const {removeUser, fetchUserProfile} = useUser();
     const [isLoading, setIsLoading] = useState<boolean>(true);
 
+    const isRootPage = useCallback(() => location.pathname === ROUTES.ROOT, [location.pathname]);
+
     const redirectToLogin = useCallback(() => {
         removeUser()
-        if (location.pathname !== ROUTES.ROOT) {
+        if (!isRootPage()) {
             console.warn("Redirecting to / page as accessing protected route without login from ", location.pathname);
             navigate(ROUTES.ROOT)
         }
-    }, [location.pathname, navigate, removeUser]);
+    }, [isRootPage, location.pathname, navigate, removeUser]);
+
 
     const validateStatus = useCallback(() => {
         const user = AppStorage.getItem(KEYS.USER);
@@ -38,24 +41,30 @@ const LoginSessionStatusChecker = () => {
         const isPasscodeRelatedRoute = location.pathname === ROUTES.USER_RESET_PASSCODE || location.pathname === ROUTES.USER_PASSCODE;
 
         /**
-         * If user is not logged in, ask them to login again or unlock wallet based on the session state.
+         * If user is not logged in, ask them to login again or unlock wallet based on the session state for a protected route.
+         * Guest routes are accessible without any restriction.
+         * Root page is a special case that is both a guest and a protected route.
+         *      - redirects to passcode page if session is active.
+         *      - redirects to home page if already logged in. (Handled in AppRouter.tsx)
+         *      - no redirection if on guest mode.
          */
-        // Redirect based on session state
-        if (isSessionActive) {
-            // User can stay on passcode routes if session is active
-            if (isPasscodeRelatedRoute) {
-                return;
+
+        if (!isLoggedIn && (isLoginProtectedRoute(location.pathname) || isRootPage())) {
+            // Redirect based on session state
+            if (isSessionActive) {
+                // User can stay on passcode routes if session is active
+                if (isPasscodeRelatedRoute) {
+                    return;
+                }
+                // Session active but wallet locked - redirect to passcode
+                console.warn('Session active but wallet locked, redirecting to passcode page');
+                navigate(ROUTES.USER_PASSCODE);
+            } else {
+                // No active session - clear user data and redirect to log in
+                redirectToLogin()
             }
-            // Session active but wallet locked - redirect to passcode
-            console.warn('Session active but wallet locked, redirecting to passcode page');
-            navigate(ROUTES.USER_PASSCODE);
         }
-        // Trying to access a login protected route without being logged in
-        else if (!isLoggedIn && isLoginProtectedRoute(location.pathname)) {
-            // No active session - clear user data and redirect to log in
-            redirectToLogin()
-        }
-    }, [navigate, location.pathname, redirectToLogin]);
+    }, [location.pathname, isRootPage, navigate, redirectToLogin]);
 
 
     const fetchUser = useCallback(async () => {

--- a/inji-web/src/components/Login/LoginFailedModal.tsx
+++ b/inji-web/src/components/Login/LoginFailedModal.tsx
@@ -19,7 +19,7 @@ export const LoginFailedModal: React.FC = () => {
           {t("LoginFailedModal.failureDescription")}
         </p>
         
-        <SolidButton testId="Login-Failure-Button" onClick={() => navigate(ROUTES.PASSCODE)} title={t("LoginFailedModal.retry")} />
+        <SolidButton testId="Login-Failure-Button" onClick={() => navigate(ROUTES.USER_PASSCODE)} title={t("LoginFailedModal.retry")} />
       </div>
     </div>
   );

--- a/inji-web/src/hooks/useInterceptor.ts
+++ b/inji-web/src/hooks/useInterceptor.ts
@@ -29,7 +29,7 @@ export function useInterceptor() {
          */
             // Redirect to / page on logged-in user if unauthorized access is detected
         const currentRoute = location.pathname + location.search + location.hash;
-        const isPasscodeRelatedRoute = location.pathname === ROUTES.USER_RESET_PASSCODE || location.pathname === ROUTES.PASSCODE;
+        const isPasscodeRelatedRoute = location.pathname === ROUTES.USER_RESET_PASSCODE || location.pathname === ROUTES.USER_PASSCODE;
 
         const isSessionActive: boolean = !!AppStorage.getItem(KEYS.USER);
         if (isUserLoggedIn() || isSessionActive) {

--- a/inji-web/src/pages/User/Passcode/PasscodePage.tsx
+++ b/inji-web/src/pages/User/Passcode/PasscodePage.tsx
@@ -65,7 +65,7 @@ export const PasscodePage: React.FC = () => {
     const unlockWallet = async (walletId: string, pin: string) => {
         if (!walletId) {
             setError(t('error.walletNotFoundError'));
-            navigate(ROUTES.PASSCODE);
+            navigate(ROUTES.USER_PASSCODE);
             throw new Error('Wallet not found');
         }
 

--- a/inji-web/src/pages/User/ResetPasscode/ResetPasscodePage.tsx
+++ b/inji-web/src/pages/User/ResetPasscode/ResetPasscodePage.tsx
@@ -21,7 +21,7 @@ export const ResetPasscodePage: React.FC = () => {
     const resetPasscodeApi = useApi()
 
     const handleBackNavigation = () => {
-        navigate(ROUTES.PASSCODE);
+        navigate(ROUTES.USER_PASSCODE);
     };
 
     const handleForgotPasscode = async () => {
@@ -37,7 +37,7 @@ export const ResetPasscodePage: React.FC = () => {
                 return
             }
             removeWallet();
-            navigate(ROUTES.PASSCODE);
+            navigate(ROUTES.USER_PASSCODE);
         } catch (error) {
             console.error('Error occurred while deleting Wallet:', error);
             setError(t('resetFailure'));

--- a/inji-web/src/utils/constants.ts
+++ b/inji-web/src/utils/constants.ts
@@ -24,7 +24,7 @@ export const Pages = {
 export const ROUTES = {
     ROOT: Pages.ROOT,
     USER: `/${Pages.USER}`,
-    PASSCODE: `/${Pages.USER}/${Pages.PASSCODE}`,
+    USER_PASSCODE: `/${Pages.USER}/${Pages.PASSCODE}`,
     USER_HOME: `/${Pages.USER}/${Pages.HOME}`,
     USER_ISSUERS: `/${Pages.USER}/${Pages.ISSUERS}`,
     ISSUERS: `/${Pages.ISSUERS}`,


### PR DESCRIPTION
* If user is not logged in, ask them to login again or unlock wallet based on the session state for a protected route.
* Guest routes are accessible without any restriction. (i.e., If user has authenticated only (i.e., session is active), and in same browser they open guest mode url (eg - <web-domain>/issuer/Mosip), guest mode url is accessible)
* Root page is a special case that is both a guest and a protected route.
         - redirects to passcode page if session is active.
         - redirects to home page if already logged in. (Handled in AppRouter.tsx)
         - no redirection if on guest mode.