### PR TITLE
[INJIWEB-1637] fix: redirect to passcode if session active on root page

### DIFF
--- a/inji-web/src/__tests__/components/LoginSessionStatusChecker.test.tsx
+++ b/inji-web/src/__tests__/components/LoginSessionStatusChecker.test.tsx
@@ -36,19 +36,56 @@ describe('LoginSessionStatusChecker', () => {
         });
     });
 
-    test('should redirect to passcode page when session is active but no wallet ID', async () => {
-        (useLocation as jest.Mock).mockReturnValue({pathname: ROUTES.CREDENTIALS});
+    const protectedRoutes = Object.entries(ROUTES)
+        .filter(([key]) => key.startsWith('USER') && key !== 'USER_ISSUER')
+        .map(([_, value]) => value);
+    protectedRoutes.push(ROUTES.USER_ISSUER("issuer1"), ROUTES.ROOT);
+
+    const protectedRoutesWithoutRoot = protectedRoutes.filter(route => route !== ROUTES.ROOT);
+
+    const nonPasscodeRelatedProtectedRoutes = protectedRoutes.filter(route => route !== ROUTES.USER_RESET_PASSCODE && route !== ROUTES.USER_PASSCODE);
+
+    const unProtectedRoutes = Object.entries(ROUTES)
+        .filter(([key]) => !key.startsWith('USER') && key !== 'ISSUER')
+        .map(([_, value]) => value);
+    unProtectedRoutes.push(ROUTES.ISSUER("issuer1"));
+
+    const passcodeRelatedRoutes = [ROUTES.USER_PASSCODE, ROUTES.USER_RESET_PASSCODE];
+
+
+    test.each(nonPasscodeRelatedProtectedRoutes)('should redirect to passcode page when session is active but no wallet ID for path %s', async (route) => {
+        (useLocation as jest.Mock).mockReturnValue({pathname: route});
         setupMockActiveSessionInStorage()
 
         render(<LoginSessionStatusChecker/>);
 
         await waitFor(() =>
-            expect(mockNavigate).toHaveBeenCalledWith(ROUTES.PASSCODE)
+            expect(mockNavigate).toHaveBeenCalledWith(ROUTES.USER_PASSCODE)
         )
     });
 
-    test('should redirect to login (root page) when accessing protected route without being logged in', async () => {
-        (useLocation as jest.Mock).mockReturnValue({pathname: ROUTES.CREDENTIALS});
+    test.each(unProtectedRoutes)('should not redirect to login when accessing unprotected route - %s with active session', (route) => {
+        (useLocation as jest.Mock).mockReturnValue({pathname: route});
+        setupMockActiveSessionInStorage();
+
+        render(<LoginSessionStatusChecker/>);
+
+        expect(mockNavigate).not.toHaveBeenCalled();
+    })
+
+    test.each(passcodeRelatedRoutes)('should not redirect to login when accessing passcode related route - %s with active session', (route) => {
+        (useLocation as jest.Mock).mockReturnValue({pathname: route});
+        setupMockActiveSessionInStorage();
+
+        render(<LoginSessionStatusChecker/>);
+
+        expect(mockNavigate).not.toHaveBeenCalled();
+        expect(mockNavigate).not.toHaveBeenCalledWith(ROUTES.USER_PASSCODE);
+    })
+
+    // In case of accessing root page, we should not redirect to root page again
+    test.each(protectedRoutesWithoutRoot)('should redirect to login (root page) when accessing protected route - %s without being logged in', async (route) => {
+        (useLocation as jest.Mock).mockReturnValue({pathname: route});
         // Mock storage with no user and no wallet ID
         (AppStorage.getItem as jest.Mock).mockReturnValue(null);
 
@@ -68,8 +105,9 @@ describe('LoginSessionStatusChecker', () => {
         expect(mockNavigate).not.toHaveBeenCalled();
     })
 
-    test('should not redirect to login when user is logged in and accessing protected route', () => {
-        (useLocation as jest.Mock).mockReturnValue({pathname: ROUTES.CREDENTIALS});
+    // Root page ("/") is a case where if logged in its redirected to user home page or not - This is handled in AppRouter so no extra redirection in LoginSessionStatusChecker
+    test.each(protectedRoutes)('should not redirect to login when user is logged in and accessing protected route - %s', (route) => {
+        (useLocation as jest.Mock).mockReturnValue({pathname: route});
         setupMockLoggedInStorage();
 
         render(<LoginSessionStatusChecker/>);
@@ -77,17 +115,17 @@ describe('LoginSessionStatusChecker', () => {
         expect(mockNavigate).not.toHaveBeenCalled();
     });
 
-    test.each([ROUTES.PASSCODE, ROUTES.USER_RESET_PASSCODE])('should not redirect to login when accessing passcode related route - %s with active session', (route) => {
+    test.each(unProtectedRoutes)('should not redirect to login when user is logged in and accessing unprotected route - %s', (route) => {
         (useLocation as jest.Mock).mockReturnValue({pathname: route});
-        setupMockActiveSessionInStorage();
+        setupMockLoggedInStorage();
 
         render(<LoginSessionStatusChecker/>);
 
         expect(mockNavigate).not.toHaveBeenCalled();
-    })
+    });
 
-    test("should not redirect to login when accessing non-protected route when session is active", () => {
-        (useLocation as jest.Mock).mockReturnValue({pathname: ROUTES.FAQ});
+    test.each(unProtectedRoutes)("should not redirect to login when accessing unprotected route - %s when session is active", (route) => {
+        (useLocation as jest.Mock).mockReturnValue({pathname: route});
         setupMockLoggedInStorage()
 
         render(<LoginSessionStatusChecker/>);

--- a/inji-web/src/__tests__/hooks/useInterceptor.test.ts
+++ b/inji-web/src/__tests__/hooks/useInterceptor.test.ts
@@ -137,7 +137,7 @@ describe("useInterceptor", () => {
         assertStoringOfCurrentLocation()
     })
 
-    test.each([ROUTES.PASSCODE, ROUTES.USER_RESET_PASSCODE])('should redirect to login when accessing protected API in passcode related page - %s and response is unauthorized', async (route) => {
+    test.each([ROUTES.USER_PASSCODE, ROUTES.USER_RESET_PASSCODE])('should redirect to login when accessing protected API in passcode related page - %s and response is unauthorized', async (route) => {
         (useLocation as jest.Mock).mockReturnValue({
             pathname: route,
             search: null,

--- a/inji-web/src/components/Login/LoginFailedModal.tsx
+++ b/inji-web/src/components/Login/LoginFailedModal.tsx
@@ -19,7 +19,7 @@ export const LoginFailedModal: React.FC = () => {
           {t("LoginFailedModal.failureDescription")}
         </p>
         
-        <SolidButton testId="Login-Failure-Button" onClick={() => navigate(ROUTES.PASSCODE)} title={t("LoginFailedModal.retry")} />
+        <SolidButton testId="Login-Failure-Button" onClick={() => navigate(ROUTES.USER_PASSCODE)} title={t("LoginFailedModal.retry")} />
       </div>
     </div>
   );

--- a/inji-web/src/hooks/useInterceptor.ts
+++ b/inji-web/src/hooks/useInterceptor.ts
@@ -29,7 +29,7 @@ export function useInterceptor() {
          */
             // Redirect to / page on logged-in user if unauthorized access is detected
         const currentRoute = location.pathname + location.search + location.hash;
-        const isPasscodeRelatedRoute = location.pathname === ROUTES.USER_RESET_PASSCODE || location.pathname === ROUTES.PASSCODE;
+        const isPasscodeRelatedRoute = location.pathname === ROUTES.USER_RESET_PASSCODE || location.pathname === ROUTES.USER_PASSCODE;
 
         const isSessionActive: boolean = !!AppStorage.getItem(KEYS.USER);
         if (isUserLoggedIn() || isSessionActive) {

--- a/inji-web/src/pages/User/Passcode/PasscodePage.tsx
+++ b/inji-web/src/pages/User/Passcode/PasscodePage.tsx
@@ -65,7 +65,7 @@ export const PasscodePage: React.FC = () => {
     const unlockWallet = async (walletId: string, pin: string) => {
         if (!walletId) {
             setError(t('error.walletNotFoundError'));
-            navigate(ROUTES.PASSCODE);
+            navigate(ROUTES.USER_PASSCODE);
             throw new Error('Wallet not found');
         }
 

--- a/inji-web/src/pages/User/ResetPasscode/ResetPasscodePage.tsx
+++ b/inji-web/src/pages/User/ResetPasscode/ResetPasscodePage.tsx
@@ -21,7 +21,7 @@ export const ResetPasscodePage: React.FC = () => {
     const resetPasscodeApi = useApi()
 
     const handleBackNavigation = () => {
-        navigate(ROUTES.PASSCODE);
+        navigate(ROUTES.USER_PASSCODE);
     };
 
     const handleForgotPasscode = async () => {
@@ -37,7 +37,7 @@ export const ResetPasscodePage: React.FC = () => {
                 return
             }
             removeWallet();
-            navigate(ROUTES.PASSCODE);
+            navigate(ROUTES.USER_PASSCODE);
         } catch (error) {
             console.error('Error occurred while deleting Wallet:', error);
             setError(t('resetFailure'));

--- a/inji-web/src/utils/constants.ts
+++ b/inji-web/src/utils/constants.ts
@@ -24,7 +24,7 @@ export const Pages = {
 export const ROUTES = {
     ROOT: Pages.ROOT,
     USER: `/${Pages.USER}`,
-    PASSCODE: `/${Pages.USER}/${Pages.PASSCODE}`,
+    USER_PASSCODE: `/${Pages.USER}/${Pages.PASSCODE}`,
     USER_HOME: `/${Pages.USER}/${Pages.HOME}`,
     USER_ISSUERS: `/${Pages.USER}/${Pages.ISSUERS}`,
     ISSUERS: `/${Pages.ISSUERS}`,


### PR DESCRIPTION
* If user is not logged in, ask them to login again or unlock wallet based on the session state for a protected route.
* Guest routes are accessible without any restriction. (i.e., If user has authenticated only (i.e., session is active), and in same browser they open guest mode url (eg - <web-domain>/issuer/Mosip), guest mode url is accessible)
* Root page is a special case that is both a guest and a protected route.
         - redirects to passcode page if session is active.
         - redirects to home page if already logged in. (Handled in AppRouter.tsx)
         - no redirection if on guest mode.