### PR TITLE
injiweb-1606: Implement anchor home page

### DIFF
--- a/inji-web/src/Router.tsx
+++ b/inji-web/src/Router.tsx
@@ -114,7 +114,7 @@ export const AppRouter = () => {
                         <LandingGuard>
                             {wrapElement(<CredentialsPage/>)}
                         </LandingGuard>
-                }
+                    }
                 />
                 <Route
                     path={Pages.FAQ}

--- a/inji-web/src/Router.tsx
+++ b/inji-web/src/Router.tsx
@@ -110,7 +110,11 @@ export const AppRouter = () => {
                 />
                 <Route
                     path={Pages.ISSUER_TEMPLATE}
-                    element={wrapElement(<CredentialsPage/>)}
+                    element={
+                        <LandingGuard>
+                            {wrapElement(<CredentialsPage/>)}
+                        </LandingGuard>
+                }
                 />
                 <Route
                     path={Pages.FAQ}

--- a/inji-web/src/Router.tsx
+++ b/inji-web/src/Router.tsx
@@ -23,6 +23,7 @@ import {ResetPasscodePage} from './pages/User/ResetPasscode/ResetPasscodePage';
 import {ProfilePage} from './pages/User/Profile/ProfilePage';
 import {Pages, ROUTES} from "./utils/constants";
 import {useInterceptor} from "./hooks/useInterceptor";
+import { LandingGuard } from "./components/Guards/LandingGuard";
 
 function RedirectToUserHome() {
     return <Navigate to={ROUTES.USER_HOME} replace/>;
@@ -101,9 +102,11 @@ export const AppRouter = () => {
                 />
                 <Route
                     path={Pages.ISSUERS}
-                    element={wrapElement(
-                        <IssuersPage className="mt-10 mb-20"/>
-                    )}
+                    element={
+                        <LandingGuard>
+                            {wrapElement(<IssuersPage className="mt-10 mb-20" />)}
+                        </LandingGuard>
+                    }
                 />
                 <Route
                     path={Pages.ISSUER_TEMPLATE}
@@ -111,7 +114,11 @@ export const AppRouter = () => {
                 />
                 <Route
                     path={Pages.FAQ}
-                    element={wrapElement(<FAQPage backUrl={ROUTES.ROOT}/>)}
+                    element={
+                        <LandingGuard>
+                            {wrapElement(<FAQPage backUrl={ROUTES.ROOT} />)}
+                        </LandingGuard>
+                    }
                 />
                 <Route
                     path={Pages.REDIRECT}

--- a/inji-web/src/__tests__/Router.test.tsx
+++ b/inji-web/src/__tests__/Router.test.tsx
@@ -101,7 +101,11 @@ describe("AppRouter", () => {
         {isLoggedIn: false, description: "guest mode", route: "/unknown", expectedText: /not found/i},
     ];
 
-    const guestModeRoutes = unProtectedRoutes
+    const guestModeRoutes = unProtectedRoutes.filter(
+        (route) => ![ROUTES.FAQ, ROUTES.ISSUERS, ROUTES.ISSUER("issuer1")].includes(route)
+    );
+
+    const protectedDeepLinks = [ROUTES.FAQ, ROUTES.ISSUERS, ROUTES.ISSUER("issuer1"),];
 
     it.each(routesWithHomeRedirectionOnLoggedIn)(
         "redirects to user home when logged in and url is $route",
@@ -177,4 +181,28 @@ describe("AppRouter", () => {
     function getPageLabelFromRoute(route: string): string {
         return `${route.charAt(1).toUpperCase() + route.slice(2)}Page`;
     }
+
+    describe("LandingGuard integration for protected deep links", () => {
+        beforeEach(() => {
+            jest.clearAllMocks();
+            sessionStorage.clear();
+            (useUserModule.useUser as jest.Mock).mockReturnValue({ isUserLoggedIn: () => false });
+        });
+
+        it.each(protectedDeepLinks)("redirects guest to HomePage when landingVisited is NOT set for %s",
+            async (route) => {
+                renderMemoryRouterWithProvider(<AppRouter />, [route]);
+                expect(await screen.findByText("HomePage")).toBeInTheDocument();
+            }
+        );
+
+        it.each(protectedDeepLinks)("allows access when landingVisited is set for %s",
+            async (route) => {
+                sessionStorage.setItem("landingVisited", "true");
+                renderMemoryRouterWithProvider(<AppRouter />, [route]);
+                const expectedText = getPageLabelFromRoute(route);
+                expect(await screen.findByText(expectedText)).toBeInTheDocument();
+            }
+        );
+    });
 });

--- a/inji-web/src/__tests__/Router.test.tsx
+++ b/inji-web/src/__tests__/Router.test.tsx
@@ -5,7 +5,7 @@ import * as useUserModule from "../hooks/User/useUser";
 import {renderMemoryRouterWithProvider} from "../test-utils/mockUtils";
 import {AppStorage} from "../utils/AppStorage";
 import {mockStore, nonPasscodeRelatedProtectedRoutes, unProtectedRoutes, userProfile} from "../test-utils/mockObjects";
-import {ROUTES} from "../utils/constants";
+import {LANDING_VISITED, ROUTES} from "../utils/constants";
 
 jest.mock('../components/Preview/PDFViewer', () => ({
     PDFViewer: ({previewContent}: {
@@ -198,7 +198,7 @@ describe("AppRouter", () => {
 
         it.each(protectedDeepLinks)("allows access when landingVisited is set for %s",
             async (route) => {
-                sessionStorage.setItem("landingVisited", "true");
+                sessionStorage.setItem(LANDING_VISITED, "true");
                 renderMemoryRouterWithProvider(<AppRouter />, [route]);
                 const expectedText = getPageLabelFromRoute(route);
                 expect(await screen.findByText(expectedText)).toBeInTheDocument();

--- a/inji-web/src/__tests__/components/Guards/LandingGuard.test.tsx
+++ b/inji-web/src/__tests__/components/Guards/LandingGuard.test.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import { LandingGuard } from "../../../components/Guards/LandingGuard";
 import { Navigate, useLocation } from "react-router-dom";
+import {LANDING_VISITED} from "../../../utils/constants";
 
 jest.mock("react-router-dom", () => ({
     ...jest.requireActual("react-router-dom"),
@@ -24,7 +25,7 @@ describe("LandingGuard", () => {
     });
 
     it.each(landingGuardTestCases)("$description", ({ sessionValue, shouldRenderChild }) => {
-        if (sessionValue) sessionStorage.setItem("landingVisited", sessionValue);
+        if (sessionValue) sessionStorage.setItem(LANDING_VISITED, sessionValue);
 
         render(<LandingGuard><TestChild /></LandingGuard>);
 

--- a/inji-web/src/__tests__/components/Guards/LandingGuard.test.tsx
+++ b/inji-web/src/__tests__/components/Guards/LandingGuard.test.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { LandingGuard } from "../../../components/Guards/LandingGuard";
+import { Navigate, useLocation } from "react-router-dom";
+
+jest.mock("react-router-dom", () => ({
+    ...jest.requireActual("react-router-dom"),
+    Navigate: ({ to }: { to: string }) => <div data-testid="navigate-mock">Navigate to {to}</div>,
+    useLocation: () => ({ pathname: "/test-path" }),
+}));
+
+const landingGuardTestCases = [
+    { sessionValue: "true", shouldRenderChild: true, description: "renders the child when landingVisited is true" },
+    { sessionValue: "false", shouldRenderChild: false, description: "redirects to root when landingVisited is false" },
+    { sessionValue: null, shouldRenderChild: false, description: "redirects to root when landingVisited is not set" },
+];
+
+describe("LandingGuard", () => {
+    const TestChild = () => <div data-testid="child">Protected Content</div>;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        sessionStorage.clear();
+    });
+
+    it.each(landingGuardTestCases)("$description", ({ sessionValue, shouldRenderChild }) => {
+        if (sessionValue) sessionStorage.setItem("landingVisited", sessionValue);
+
+        render(<LandingGuard><TestChild /></LandingGuard>);
+
+        if (shouldRenderChild) {
+            expect(screen.getByTestId("child")).toBeInTheDocument();
+            expect(screen.queryByTestId("navigate-mock")).not.toBeInTheDocument();
+        } else {
+            expect(screen.getByTestId("navigate-mock")).toHaveTextContent("Navigate to /");
+            expect(screen.queryByTestId("child")).not.toBeInTheDocument();
+        }
+    });
+});

--- a/inji-web/src/__tests__/pages/HomePage.test.tsx
+++ b/inji-web/src/__tests__/pages/HomePage.test.tsx
@@ -5,6 +5,7 @@ import { Provider } from 'react-redux';
 import { HomePage } from '../../pages/HomePage';
 import { toast } from 'react-toastify';
 import { AppToaster } from '../../components/Common/toast/AppToaster';
+import {LANDING_VISITED} from "../../utils/constants";
 
 // Mock redux store
 const mockStore = {
@@ -81,7 +82,7 @@ describe('HomePage', () => {
   test('sets landingVisited flag in sessionStorage on mount', () => {
       const setItemSpy = jest.spyOn(window.sessionStorage.__proto__, 'setItem');
       renderComponent();
-      expect(setItemSpy).toHaveBeenCalledWith('landingVisited', 'true');
+      expect(setItemSpy).toHaveBeenCalledWith(LANDING_VISITED, 'true');
   });
 
   test('logs a warning if sessionStorage.setItem fails', () => {
@@ -95,7 +96,7 @@ describe('HomePage', () => {
 
       renderComponent();
 
-      expect(setItemSpy).toHaveBeenCalledWith('landingVisited', 'true');
+      expect(setItemSpy).toHaveBeenCalledWith(LANDING_VISITED, 'true');
       expect(warnSpy).toHaveBeenCalledWith(
           'Unable to access sessionStorage',
           expect.any(Error)

--- a/inji-web/src/__tests__/pages/HomePage.test.tsx
+++ b/inji-web/src/__tests__/pages/HomePage.test.tsx
@@ -78,6 +78,30 @@ describe('HomePage', () => {
     jest.clearAllMocks(); 
   });
 
+  test('sets landingVisited flag in sessionStorage on mount', () => {
+      const setItemSpy = jest.spyOn(window.sessionStorage.__proto__, 'setItem');
+      renderComponent();
+      expect(setItemSpy).toHaveBeenCalledWith('landingVisited', 'true');
+  });
+
+  test('logs a warning if sessionStorage.setItem fails', () => {
+      const setItemSpy = jest
+          .spyOn(window.sessionStorage.__proto__, 'setItem')
+          .mockImplementation(() => {
+              throw new Error('storage failed');
+          });
+
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      renderComponent();
+
+      expect(setItemSpy).toHaveBeenCalledWith('landingVisited', 'true');
+      expect(warnSpy).toHaveBeenCalledWith(
+          'Unable to access sessionStorage',
+          expect.any(Error)
+      );
+  });
+
   test('renders HomeBanner, HomeFeatures, and HomeQuickTip components', () => {
     renderComponent();
     expect(screen.getByTestId('HomeBanner')).toBeInTheDocument();

--- a/inji-web/src/__tests__/users/login/Login.test.tsx
+++ b/inji-web/src/__tests__/users/login/Login.test.tsx
@@ -38,12 +38,28 @@ describe("Login Page Tests", () => {
     expect(screen.getByTestId("home-banner-guest-login")).toHaveTextContent("Continue as Guest");
   });
 
-  test("Guest login button navigates to issuers page", () => {
-    render(<MemoryRouter><Login /></MemoryRouter>);
-    const guestButton = screen.getByTestId("home-banner-guest-login");
+  test("Guest login button navigates correctly based on location state", () => {
+      const testFromPath = "/faq";
 
-    fireEvent.click(guestButton);
-    expect(mockNavigate).toHaveBeenCalledWith("/issuers");
+      render(
+          <MemoryRouter initialEntries={[{ pathname: "/", state: { from: { pathname: testFromPath } } }]}>
+              <Login />
+          </MemoryRouter>
+      );
+
+      const guestButton = screen.getByTestId("home-banner-guest-login");
+      fireEvent.click(guestButton);
+
+      expect(mockNavigate).toHaveBeenCalledWith(testFromPath, { replace: true });
+  });
+
+  test("Guest login button navigates to /issuers if no state is provided", () => {
+      render(<MemoryRouter><Login /></MemoryRouter>);
+
+      const guestButton = screen.getByTestId("home-banner-guest-login");
+      fireEvent.click(guestButton);
+
+      expect(mockNavigate).toHaveBeenCalledWith("/issuers", { replace: true });
   });
 
   test("Google login button redirects to Google OAuth URL", () => {

--- a/inji-web/src/components/Guards/LandingGuard.tsx
+++ b/inji-web/src/components/Guards/LandingGuard.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { Navigate, useLocation } from "react-router-dom";
+import { hasVisitedLanding } from "../../utils/sessions";
+
+interface LandingGuardProps {
+    children: React.ReactNode;
+}
+
+export const LandingGuard: React.FC<LandingGuardProps> = ({ children }) => {
+    const location = useLocation();
+
+    if (!hasVisitedLanding()) {
+        return <Navigate to="/" replace state={{ from: location }} />;
+    }
+
+    return <>{children}</>;
+};
+
+export default LandingGuard;

--- a/inji-web/src/components/Guards/LandingGuard.tsx
+++ b/inji-web/src/components/Guards/LandingGuard.tsx
@@ -25,7 +25,6 @@ export const LandingGuard: React.FC<LandingGuardProps> = ({ children }) => {
         return null;
     }
 
-
     if (!visited) {
         return <Navigate to="/" replace state={{ from: location }} />;
     }

--- a/inji-web/src/components/Guards/LandingGuard.tsx
+++ b/inji-web/src/components/Guards/LandingGuard.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Navigate, useLocation } from "react-router-dom";
 
 interface LandingGuardProps {
@@ -7,16 +7,26 @@ interface LandingGuardProps {
 
 export const LandingGuard: React.FC<LandingGuardProps> = ({ children }) => {
     const location = useLocation();
+    const [isLoading, setIsLoading] = useState(true);
+    const [visited, setVisited] = useState(false);
 
-    const hasVisitedLanding = () => {
+    useEffect(() => {
         try {
-            return sessionStorage.getItem("landingVisited") === "true";
+            const flag = sessionStorage.getItem("landingVisited") === "true";
+            setVisited(flag);
         } catch {
-            return false;
+            setVisited(false);
+        } finally {
+            setIsLoading(false);
         }
-    };
+    }, []);
 
-    if (!hasVisitedLanding()) {
+    if (isLoading) {
+        return null;
+    }
+
+
+    if (!visited) {
         return <Navigate to="/" replace state={{ from: location }} />;
     }
 

--- a/inji-web/src/components/Guards/LandingGuard.tsx
+++ b/inji-web/src/components/Guards/LandingGuard.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { Navigate, useLocation } from "react-router-dom";
+import {SpinningLoader} from "../Common/SpinningLoader";
+import {LANDING_VISITED} from "../../utils/constants";
 
 interface LandingGuardProps {
     children: React.ReactNode;
@@ -12,7 +14,7 @@ export const LandingGuard: React.FC<LandingGuardProps> = ({ children }) => {
 
     useEffect(() => {
         try {
-            const flag = sessionStorage.getItem("landingVisited") === "true";
+            const flag = sessionStorage.getItem(LANDING_VISITED) === "true";
             setVisited(flag);
         } catch {
             setVisited(false);
@@ -22,7 +24,7 @@ export const LandingGuard: React.FC<LandingGuardProps> = ({ children }) => {
     }, []);
 
     if (isLoading) {
-        return null;
+        return <SpinningLoader />;
     }
 
     if (!visited) {

--- a/inji-web/src/components/Guards/LandingGuard.tsx
+++ b/inji-web/src/components/Guards/LandingGuard.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { Navigate, useLocation } from "react-router-dom";
-import { hasVisitedLanding } from "../../utils/sessions";
 
 interface LandingGuardProps {
     children: React.ReactNode;
@@ -8,6 +7,14 @@ interface LandingGuardProps {
 
 export const LandingGuard: React.FC<LandingGuardProps> = ({ children }) => {
     const location = useLocation();
+
+    const hasVisitedLanding = () => {
+        try {
+            return sessionStorage.getItem("landingVisited") === "true";
+        } catch {
+            return false;
+        }
+    };
 
     if (!hasVisitedLanding()) {
         return <Navigate to="/" replace state={{ from: location }} />;

--- a/inji-web/src/components/Login/Login.tsx
+++ b/inji-web/src/components/Login/Login.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import {useNavigate} from "react-router-dom";
+import {useNavigate, useLocation} from "react-router-dom";
 import '../../index.css';
 import {useTranslation} from "react-i18next";
 import {BorderedButton} from "../Common/Buttons/BorderedButton";
@@ -8,9 +8,15 @@ import {GoogleSignInButton} from "../Common/Buttons/GoogleSignInButton";
 export const Login: React.FC = () => {
   const { t } = useTranslation("HomePage");
   const navigate = useNavigate();
+  const location = useLocation();
 
   const handleGoogleLogin = () => {
       window.location.href = `${window._env_.MIMOTO_URL}/oauth2/authorize/google`;
+  };
+
+  const handleGuestLogin = () => {
+      const redirectPath = location.state?.from?.pathname || "/issuers";
+      navigate(redirectPath, { replace: true });
   };
 
   const Separator:React.FC=()=>{
@@ -48,7 +54,7 @@ export const Login: React.FC = () => {
         <div className="w-full">
           <BorderedButton
               testId="home-banner-guest-login"
-              onClick={() => navigate("/issuers")}
+              onClick={handleGuestLogin}
               title={
               t("Login.loginGuest")
             }

--- a/inji-web/src/pages/HomePage.tsx
+++ b/inji-web/src/pages/HomePage.tsx
@@ -6,6 +6,7 @@ import {toast} from "react-toastify";
 import {useTranslation} from "react-i18next";
 import {useLocation} from 'react-router-dom';
 import {LoginFailedModal} from '../components/Login/LoginFailedModal';
+import {LANDING_VISITED} from "../utils/constants";
 
 const Status = {
     SUCCESS: "success",
@@ -21,7 +22,7 @@ export const HomePage: React.FC = () => {
     // to mark landing as visited
     useEffect(() => {
         try {
-            sessionStorage.setItem("landingVisited", "true");
+            sessionStorage.setItem(LANDING_VISITED, "true");
         } catch (e) {
             console.warn("Unable to access sessionStorage", e);
         }

--- a/inji-web/src/pages/HomePage.tsx
+++ b/inji-web/src/pages/HomePage.tsx
@@ -5,8 +5,7 @@ import {HomeQuickTip} from "../components/Home/HomeQuickTip";
 import {toast} from "react-toastify";
 import {useTranslation} from "react-i18next";
 import {useLocation} from 'react-router-dom';
-import {LoginFailedModal} from '../components/Login/LoginFailedModal'
-import { setLandingVisited } from "../utils/sessions";
+import {LoginFailedModal} from '../components/Login/LoginFailedModal';
 
 const Status = {
     SUCCESS: "success",
@@ -21,7 +20,12 @@ export const HomePage: React.FC = () => {
 
     // to mark landing as visited
     useEffect(() => {
-        setLandingVisited();
+        try {
+            sessionStorage.setItem("landingVisited", "true");
+            console.log("Landing page visited marked in sessionStorage");
+        } catch (e) {
+            console.warn("Unable to access sessionStorage", e);
+        }
     }, []);
 
     // to stop scrolling the blurred background when login failed modal is showing up, scrolling is locked.
@@ -37,7 +41,7 @@ export const HomePage: React.FC = () => {
         };
     }, [isLoginFailed]);
 
-    // If google login is failing,show login failed modal 
+    // If google login is failing,show login failed modal
     useEffect(() => {
         const params = new URLSearchParams(location.search);
         if (params.get("status") === Status.FAILURE) {

--- a/inji-web/src/pages/HomePage.tsx
+++ b/inji-web/src/pages/HomePage.tsx
@@ -6,6 +6,7 @@ import {toast} from "react-toastify";
 import {useTranslation} from "react-i18next";
 import {useLocation} from 'react-router-dom';
 import {LoginFailedModal} from '../components/Login/LoginFailedModal'
+import { setLandingVisited } from "../utils/sessions";
 
 const Status = {
     SUCCESS: "success",
@@ -18,6 +19,10 @@ export const HomePage: React.FC = () => {
     const location = useLocation();
     const [isLoginFailed, setIsLoginFailed] = useState(false);
 
+    // to mark landing as visited
+    useEffect(() => {
+        setLandingVisited();
+    }, []);
 
     // to stop scrolling the blurred background when login failed modal is showing up, scrolling is locked.
     useEffect(() => {

--- a/inji-web/src/pages/HomePage.tsx
+++ b/inji-web/src/pages/HomePage.tsx
@@ -22,7 +22,6 @@ export const HomePage: React.FC = () => {
     useEffect(() => {
         try {
             sessionStorage.setItem("landingVisited", "true");
-            console.log("Landing page visited marked in sessionStorage");
         } catch (e) {
             console.warn("Unable to access sessionStorage", e);
         }

--- a/inji-web/src/utils/constants.ts
+++ b/inji-web/src/utils/constants.ts
@@ -61,3 +61,5 @@ export enum RequestStatus {
 export const pdfWorkerSource = (pdfVersion : string) => `//unpkg.com/pdfjs-dist@${pdfVersion}/build/pdf.worker.min.mjs`;
 
 export const passcodeLength = 6;
+
+export const LANDING_VISITED = "landingVisited";

--- a/inji-web/src/utils/sessions.ts
+++ b/inji-web/src/utils/sessions.ts
@@ -24,12 +24,3 @@ export const removeActiveSession = (state: string) => {
     const remainingSessions = getAllActiveSession().filter(session => session.state !== state);
     AppStorage.setItem(AppStorage.SESSION_INFO, JSON.stringify(remainingSessions));
 }
-
-export function setLandingVisited() {
-    document.cookie = "landingVisited=true; path=/";
-}
-
-export function hasVisitedLanding(): boolean {
-    return document.cookie.split("; ").some((c) => c.startsWith("landingVisited="));
-}
-

--- a/inji-web/src/utils/sessions.ts
+++ b/inji-web/src/utils/sessions.ts
@@ -25,3 +25,11 @@ export const removeActiveSession = (state: string) => {
     AppStorage.setItem(AppStorage.SESSION_INFO, JSON.stringify(remainingSessions));
 }
 
+export function setLandingVisited() {
+    document.cookie = "landingVisited=true; path=/";
+}
+
+export function hasVisitedLanding(): boolean {
+    return document.cookie.split("; ").some((c) => c.startsWith("landingVisited="));
+}
+


### PR DESCRIPTION
**injiweb-1606: Implement anchor home page**

Primary aim is to redirect users to the landing page on their first visit. 

Deep links such as `/faq` and `/issuers` and `/issuers/*` are to be protected until the landing page is visited once.
 
Implements session-based logic  and preserves the originally requested route after guest login.

Tests completed