### PR TITLE
[INJIWEB-1717] - Fix resource name include to datashare

### DIFF
--- a/inji-web/src/__tests__/pages/AuthorizationPage.test.tsx
+++ b/inji-web/src/__tests__/pages/AuthorizationPage.test.tsx
@@ -9,7 +9,7 @@ jest.mock("../../utils/api", () => ({
 
 describe('Testing the Layouts of AuthorizationPage', () => {
   test('Check if it renders properly if there is no error in URL', () => {
-    mockWindowLocation('https://api.collab.mosip.net?resource=datashare-service&datashare=test');
+    mockWindowLocation('https://api.collab.mosip.net?resource=datashare&datashare=test');
     const {asFragment} = renderWithRouter(<AuthorizationPage />);
     expect(asFragment()).toMatchSnapshot();
   });

--- a/inji-web/src/pages/AuthorizationPage.tsx
+++ b/inji-web/src/pages/AuthorizationPage.tsx
@@ -14,7 +14,7 @@ export const AuthorizationPage: React.FC = () => {
     useEffect( () => {
         if(url.indexOf("error") === -1) {
             const resource = currentQueryParams.get("resource");
-            if (resource && resource.includes("datashare-service")) {
+            if (resource && resource.includes("datashare")) {
                 //Datashare flow - stay on /authorize
                 window.location.href = api.mimotoHost + "/authorize" + window.location.search;
             } else {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Authorization flow now correctly identifies all datashare resources for proper handling on the authorization page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->