### PR TITLE
Fixed the issue where issuer descriptions were not displayed

### DIFF
--- a/inji-web/src/components/Common/ItemBox.tsx
+++ b/inji-web/src/components/Common/ItemBox.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {ItemBoxProps} from '../../types/components';
+import { ItemBoxProps } from '../../types/components';
 
 export const ItemBox: React.FC<ItemBoxProps> = (props) => {
     return (
@@ -25,6 +25,14 @@ export const ItemBox: React.FC<ItemBoxProps> = (props) => {
                 >
                     {props.title}
                 </h3>
+                {props.description && (
+                    <p
+                        className="text-xs text-gray-600 text-center w-[150px] mt-2 break-words"
+                        data-testid="ItemBox-Description"
+                    >
+                        {props.description}
+                    </p>
+                )}
             </div>
         </div>
     );


### PR DESCRIPTION
The description now appears below the issuer title in the issuer cards
It only renders when a description is available (since it's optional)
Styled to differentiate from the title while maintaining visual consistency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced item boxes with conditional description display, allowing additional contextual information to be shown when provided.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->