### PR TITLE
[INJIWEB-1762] - Fix CredentialItem clickable with keyboard accessibility and tests

### DIFF
--- a/inji-web/src/__tests__/components/Credentials/CredentialItem.test.tsx
+++ b/inji-web/src/__tests__/components/Credentials/CredentialItem.test.tsx
@@ -1,0 +1,177 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { CredentialItem } from '../../../components/Credentials/CredentialItem';
+import { PresentationCredential } from '../../../types/components';
+
+jest.mock('../../../hooks/useCredentialItem', () => ({
+    useCredentialItem: ({ credentialId, onToggle }: any) => ({
+        imageError: false,
+        handleToggle: () => onToggle(credentialId),
+        handleImageError: jest.fn()
+    })
+}));
+
+describe('CredentialItem Component', () => {
+    const mockCredential: PresentationCredential = {
+        credentialId: 'test-cred-1',
+        credentialTypeDisplayName: 'Test Credential',
+        credentialTypeLogo: '/test-logo.png',
+        format: 'ldp_vc'
+    };
+
+    const mockOnToggle = jest.fn();
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('Selection functionality', () => {
+        it('should call onToggle when clicking the div', () => {
+            render(
+                <CredentialItem
+                    credential={mockCredential}
+                    isSelected={false}
+                    onToggle={mockOnToggle}
+                />
+            );
+
+            // Find the clickable div using role="button" within the item container
+            const itemContainer = screen.getByTestId(`item-${mockCredential.credentialId}`);
+            const clickableDiv = itemContainer.querySelector('div[role="button"]');
+            expect(clickableDiv).toBeInTheDocument();
+
+            fireEvent.click(clickableDiv!);
+            expect(mockOnToggle).toHaveBeenCalledTimes(1);
+            expect(mockOnToggle).toHaveBeenCalledWith(mockCredential.credentialId);
+        });
+
+        it('should call onToggle when pressing Enter key on div', () => {
+            render(
+                <CredentialItem
+                    credential={mockCredential}
+                    isSelected={false}
+                    onToggle={mockOnToggle}
+                />
+            );
+            // Find the clickable div using role="button"
+            const itemContainer = screen.getByTestId(`item-${mockCredential.credentialId}`);
+            const clickableDiv = itemContainer.querySelector('div[role="button"]') as HTMLElement;
+            expect(clickableDiv).toBeInTheDocument();
+            
+            fireEvent.keyDown(clickableDiv, { key: 'Enter' });
+            expect(mockOnToggle).toHaveBeenCalledTimes(1);
+            expect(mockOnToggle).toHaveBeenCalledWith(mockCredential.credentialId);
+        });
+
+        it('should call onToggle when pressing Space key on div', () => {
+            render(
+                <CredentialItem
+                    credential={mockCredential}
+                    isSelected={false}
+                    onToggle={mockOnToggle}
+                />
+            );
+            // Find the clickable div using role="button"
+            const itemContainer = screen.getByTestId(`item-${mockCredential.credentialId}`);
+            const clickableDiv = itemContainer.querySelector('div[role="button"]') as HTMLElement;
+            expect(clickableDiv).toBeInTheDocument();
+            
+            fireEvent.keyDown(clickableDiv, { key: ' ' });
+            expect(mockOnToggle).toHaveBeenCalledTimes(1);
+            expect(mockOnToggle).toHaveBeenCalledWith(mockCredential.credentialId);
+        });
+
+        it('should apply selected styles when isSelected is true', () => {
+            render(
+                <CredentialItem
+                    credential={mockCredential}
+                    isSelected={true}
+                    onToggle={mockOnToggle}
+                />
+            );
+            // Find the clickable div using role="button"
+            const itemContainer = screen.getByTestId(`item-${mockCredential.credentialId}`);
+            const clickableDiv = itemContainer.querySelector('div[role="button"]');
+            expect(clickableDiv).toBeInTheDocument();
+            expect(clickableDiv).toHaveClass('bg-orange-50');
+        });
+
+        it('should not apply selected styles when isSelected is false', () => {
+            render(
+                <CredentialItem
+                    credential={mockCredential}
+                    isSelected={false}
+                    onToggle={mockOnToggle}
+                />
+            );
+            // Find the clickable div using role="button"
+            const itemContainer = screen.getByTestId(`item-${mockCredential.credentialId}`);
+            const clickableDiv = itemContainer.querySelector('div[role="button"]');
+            expect(clickableDiv).toBeInTheDocument();
+            expect(clickableDiv).not.toHaveClass('bg-orange-50');
+        });
+
+        it('should call onToggle when clicking the checkbox', () => {
+            render(
+                <CredentialItem
+                    credential={mockCredential}
+                    isSelected={false}
+                    onToggle={mockOnToggle}
+                />
+            );
+
+            const checkbox = screen.getByTestId(`checkbox-${mockCredential.credentialId}`);
+            expect(checkbox).toBeInTheDocument();
+
+            fireEvent.click(checkbox);
+            expect(mockOnToggle).toHaveBeenCalledTimes(1);
+            expect(mockOnToggle).toHaveBeenCalledWith(mockCredential.credentialId);
+        });
+
+        it('should not trigger double-toggle when clicking checkbox (stopPropagation works)', () => {
+            render(
+                <CredentialItem
+                    credential={mockCredential}
+                    isSelected={false}
+                    onToggle={mockOnToggle}
+                />
+            );
+
+            const checkbox = screen.getByTestId(`checkbox-${mockCredential.credentialId}`);
+            
+            // Click checkbox - should only trigger once due to stopPropagation
+            // If stopPropagation didn't work, the div's onClick would also fire, causing double-toggle
+            fireEvent.click(checkbox);
+            
+            expect(mockOnToggle).toHaveBeenCalledTimes(1);
+            expect(mockOnToggle).toHaveBeenCalledWith(mockCredential.credentialId);
+        });
+
+        it('should display selected state correctly', () => {
+            render(
+                <CredentialItem
+                    credential={mockCredential}
+                    isSelected={true}
+                    onToggle={mockOnToggle}
+                />
+            );
+
+            const checkbox = screen.getByTestId(`checkbox-${mockCredential.credentialId}`);
+            expect(checkbox).toBeChecked();
+        });
+
+        it('should display unselected state correctly', () => {
+            render(
+                <CredentialItem
+                    credential={mockCredential}
+                    isSelected={false}
+                    onToggle={mockOnToggle}
+                />
+            );
+
+            const checkbox = screen.getByTestId(`checkbox-${mockCredential.credentialId}`);
+            expect(checkbox).not.toBeChecked();
+        });
+    });
+});
+

--- a/inji-web/src/__tests__/components/Credentials/__snapshots__/PresentationCredentialList.test.tsx.snap
+++ b/inji-web/src/__tests__/components/Credentials/__snapshots__/PresentationCredentialList.test.tsx.snap
@@ -100,8 +100,11 @@ exports[`Testing the Layout of PresentationCredentialList Check if the layout is
       style="padding: 0px; border-radius: 8px;"
     >
       <div
+        aria-label="Select Health Insurance credential"
         class="w-full !h-[78px] rounded-lg flex items-center justify-between transition-colors !bg-[var(--iw-color-tileBackground)] !border-[var(--iw-color-borderLight)] hover:!bg-[var(--iw-color-faqAccordionHover)] p-3 shadow-md "
-        style="border-radius: 8px; transform: none; height: 100%; width: 100%;"
+        role="button"
+        style="border-radius: 8px; transform: none; height: 100%; width: 100%; cursor: pointer;"
+        tabindex="0"
       >
         <div
           class="flex items-center space-x-3 min-w-0 flex-1"
@@ -137,7 +140,7 @@ exports[`Testing the Layout of PresentationCredentialList Check if the layout is
             class="rounded focus:ring-2 focus:!ring-[var(--iw-color-primary)] w-5 h-5"
             data-testid="checkbox-InsuranceCredential"
             role="checkbox"
-            style="appearance: none; border: 1px solid #d1d5db; background-color: rgb(249, 250, 251); position: relative;"
+            style="appearance: none; border: 1px solid #d1d5db; background-color: rgb(249, 250, 251); position: relative; cursor: pointer;"
             type="checkbox"
           />
         </div>
@@ -151,8 +154,11 @@ exports[`Testing the Layout of PresentationCredentialList Check if the layout is
       style="padding: 0px; border-radius: 8px;"
     >
       <div
+        aria-label="Select Another Credential credential"
         class="w-full !h-[78px] rounded-lg flex items-center justify-between transition-colors !bg-[var(--iw-color-tileBackground)] !border-[var(--iw-color-borderLight)] hover:!bg-[var(--iw-color-faqAccordionHover)] p-3 shadow-md "
-        style="border-radius: 8px; transform: none; height: 100%; width: 100%;"
+        role="button"
+        style="border-radius: 8px; transform: none; height: 100%; width: 100%; cursor: pointer;"
+        tabindex="0"
       >
         <div
           class="flex items-center space-x-3 min-w-0 flex-1"
@@ -188,7 +194,7 @@ exports[`Testing the Layout of PresentationCredentialList Check if the layout is
             class="rounded focus:ring-2 focus:!ring-[var(--iw-color-primary)] w-5 h-5"
             data-testid="checkbox-AnotherCredential"
             role="checkbox"
-            style="appearance: none; border: 1px solid #d1d5db; background-color: rgb(249, 250, 251); position: relative;"
+            style="appearance: none; border: 1px solid #d1d5db; background-color: rgb(249, 250, 251); position: relative; cursor: pointer;"
             type="checkbox"
           />
         </div>

--- a/inji-web/src/components/Credentials/CredentialItem.tsx
+++ b/inji-web/src/components/Credentials/CredentialItem.tsx
@@ -45,7 +45,18 @@ export const CredentialItem = memo<CredentialItemProps>(({
                     transform: isSelected ? 'translate(0.2px, 0.2px)' : 'none',
                     height: isSelected ? 'calc(100% - 0.5px)' : '100%',
                     width: isSelected ? 'calc(100% - 0.5px)' : '100%',
+                    cursor: 'pointer'
                 }}
+                onClick={handleToggle}
+                role="button"
+                tabIndex={0}
+                onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        handleToggle();
+                    }
+                }}
+                aria-label={`${isSelected ? 'Deselect' : 'Select'} ${credentialName} credential`}
             >
                 <div className={CredentialRequestModalStyles.content.credentialContent}>
                     {/* Credential Logo */}
@@ -79,7 +90,10 @@ export const CredentialItem = memo<CredentialItemProps>(({
                 </div>
 
                 {/* Checkbox */}
-                <div className={CredentialRequestModalStyles.content.checkboxContainer}>
+                <div 
+                    className={CredentialRequestModalStyles.content.checkboxContainer}
+                    onClick={(e) => e.stopPropagation()}
+                >
                     <input
                         data-testid={`checkbox-${credential.credentialId}`}
                         type="checkbox"
@@ -90,9 +104,10 @@ export const CredentialItem = memo<CredentialItemProps>(({
                             appearance: 'none',
                             border: isSelected ? 'none' : '1px solid #d1d5db',
                             backgroundColor: isSelected ? 'transparent' : '#f9fafb',
-                            position: 'relative'
+                            position: 'relative',
+                            cursor: 'pointer'
                         }}
-                        aria-label={`Select ${credentialName} credential`}
+                        aria-label={`${isSelected ? 'Deselect' : 'Select'} ${credentialName} credential`}
                         aria-checked={isSelected}
                         role="checkbox"
                     />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Credential items are now clickable for toggling selection.
  * Added keyboard support: press Enter or Space to select/deselect credentials.
  * Visual feedback highlights selected credentials.

* **Bug Fixes**
  * Fixed event propagation to prevent unintended double-toggles when interacting with checkboxes.

* **Tests**
  * Added comprehensive test coverage for credential item interactions and accessibility features.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->