### PR TITLE
fix: [INJIWEB-1145] changed Selected Document to Selected Credential

### DIFF
--- a/inji-web/src/locales/ar.json
+++ b/inji-web/src/locales/ar.json
@@ -373,7 +373,7 @@
     "title": "صلاحية المشاركة",
     "subTitle": "يرجى تقديم موافقتك على تعيين صلاحية مشاركة {{credentialName}}",
     "content": {
-      "selectedDocument": "المستند المحدد",
+      "selectedDocument": "بيانات الاعتماد المختارة",
       "consent": "صلاحية الموافقة *",
       "validityTimesHeader": "عدد المرات",
       "validityTimesOptions": {

--- a/inji-web/src/locales/en.json
+++ b/inji-web/src/locales/en.json
@@ -373,7 +373,7 @@
     "title": "Share Validity",
     "subTitle": "Please provide your consent to set a validity for sharing the {{credentialName}}",
     "content": {
-      "selectedDocument": "Selected Document",
+      "selectedDocument": "Selected Credential",
       "consent": "Consent Validity *",
       "validityTimesHeader": "Number of times",
       "validityTimesOptions": {

--- a/inji-web/src/locales/fr.json
+++ b/inji-web/src/locales/fr.json
@@ -373,7 +373,7 @@
     "title": "Validité du partage",
     "subTitle": "Veuillez donner votre consentement pour définir une validité pour le partage du {{credentialName}}",
     "content": {
-      "selectedDocument": "Document sélectionné",
+      "selectedDocument": "Identifiant sélectionné",
       "consent": "Validité du consentement *",
       "validityTimesHeader": "Nombre de fois",
       "validityTimesOptions": {

--- a/inji-web/src/locales/hi.json
+++ b/inji-web/src/locales/hi.json
@@ -373,7 +373,7 @@
     "title": "वैधता साझा करें",
     "subTitle": "कृपया साझा करने की वैधता निर्धारित करने के लिए अपनी सहमति प्रदान करें {{credentialName}}",
     "content": {
-      "selectedDocument": "चयनित दस्तावेज़",
+      "selectedDocument": "चयनित क्रेडेंशियल",
       "consent": "सहमति की वैधता *",
       "validityTimesHeader": "कितनी बार",
       "validityTimesOptions": {

--- a/inji-web/src/locales/kn.json
+++ b/inji-web/src/locales/kn.json
@@ -373,7 +373,7 @@
     "title": "ಹಂಚಿಕೆ ಮಾನ್ಯತೆ",
     "subTitle": "ಹಂಚಿಕೊಳ್ಳಲು ಮಾನ್ಯತೆಯನ್ನು ಹೊಂದಿಸಲು ದಯವಿಟ್ಟು ನಿಮ್ಮ ಒಪ್ಪಿಗೆಯನ್ನು ಒದಗಿಸಿ {{credentialName}}",
     "content": {
-      "selectedDocument": "ಆಯ್ದ ಡಾಕ್ಯುಮೆಂಟ್",
+      "selectedDocument": "ಆಯ್ಕೆಮಾಡಿದ ರುಜುವಾತು",
       "consent": "ಸಮ್ಮತಿ ಸಿಂಧುತ್ವ *",
       "validityTimesHeader": "ಬಾರಿ ಸಂಖ್ಯೆ",
       "validityTimesOptions": {

--- a/inji-web/src/locales/pt.json
+++ b/inji-web/src/locales/pt.json
@@ -373,7 +373,7 @@
     "title": "Compartilhar Validade",
     "subTitle": "Por favor, dê seu consentimento para definir uma validade para compartilhar o {{credentialName}}",
     "content": {
-      "selectedDocument": "Documento selecionado",
+      "selectedDocument": "Credencial selecionada",
       "consent": "Consentimento Validade *",
       "validityTimesHeader": "Número de vezes",
       "validityTimesOptions": {

--- a/inji-web/src/locales/ta.json
+++ b/inji-web/src/locales/ta.json
@@ -373,7 +373,7 @@
     "title": "பங்கு செல்லுபடியாகும்",
     "subTitle": "பகிர்வதற்கான செல்லுபடியை அமைக்க உங்கள் ஒப்புதலை வழங்கவும் {{credentialName}}",
     "content": {
-      "selectedDocument": "தேர்ந்தெடுக்கப்பட்ட ஆவணம்",
+      "selectedDocument": "தேர்ந்தெடுக்கப்பட்ட நற்சான்றிதழ்",
       "consent": "ஒப்புதல் செல்லுபடியாகும் *",
       "validityTimesHeader": "முறைகளின் எண்ணிக்கை",
       "validityTimesOptions": {


### PR DESCRIPTION
## Description
Changed "Selected Document" to "Selected Credential" in language translation files for consistent terminology across the application.

## Changes:
- Updated translation keys in JSON language files
- Changed all instances of "Selected Document" to "Selected Credential"

## Issue ticket number and link
[INJIWEB-1145](https://mosip.atlassian.net/browse/INJIWEB-1145)

## Screenshot
<img width="1589" height="809" alt="image" src="https://github.com/user-attachments/assets/8f8a2fc3-30d0-485d-9ac8-4af3f588868d" />

## Video
https://github.com/user-attachments/assets/297afca1-9e6d-44b1-9d15-dc20ec78e733

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated localization strings across seven languages (English, Arabic, French, Hindi, Kannada, Portuguese, and Tamil). Changed the displayed label from "Selected Document" to "Selected Credential" in the data sharing expiry modal for improved terminology clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->