### PR TITLE
INJIWEB-1683

### DIFF
--- a/inji-web/src/pages/User/Passcode/PasscodePage.tsx
+++ b/inji-web/src/pages/User/Passcode/PasscodePage.tsx
@@ -10,14 +10,14 @@ import {HTTP_STATUS_CODES, KEYS, NETWORK_ERROR_MESSAGE, passcodeLength, ROUTES} 
 import {PasscodePageTemplate} from "../../../components/PageTemplate/PasscodePage/PasscodePageTemplate";
 import {TertiaryButton} from "../../../components/Common/Buttons/TertiaryButton";
 import {useApi} from "../../../hooks/useApi";
-import {ApiError, ApiResult, ErrorType, Wallet} from "../../../types/data";
+import {ApiError, ApiResult, Wallet} from "../../../types/data";
 import {AppStorage} from "../../../utils/AppStorage";
 
 const WalletLockStatus = {
     TEMPORARILY_LOCKED: 'temporarily_locked',
     PERMANENTLY_LOCKED: 'permanently_locked',
     LAST_ATTEMPT_BEFORE_LOCKOUT: 'last_attempt_before_lockout'
-}
+};
 
 const walletStatusToTestIdSuffix: Record<string, string> = {
     [WalletLockStatus.TEMPORARILY_LOCKED]: 'temporarily-locked',
@@ -30,7 +30,7 @@ export const PasscodePage: React.FC = () => {
     const navigate = useNavigate();
     const [error, setError] = useState<string | null>(null);
     const [loading, setLoading] = useState<boolean>(false);
-    const [wallets, setWallets] = useState<any[] | null>(null);
+  const [wallets, setWallets] = useState<Wallet[] | null>(null);
 
     const initialPasscodeArray = Array(passcodeLength).fill('');
     const [passcode, setPasscode] = useState<string[]>(initialPasscodeArray);
@@ -42,6 +42,9 @@ export const PasscodePage: React.FC = () => {
     const unlockWalletApi = useApi<Wallet>();
     const [canUnlockWallet, setCanUnlockWallet] = useState<boolean>(true);
     const [testIdSuffix, setTestIdSuffix] = useState("");
+  const [remainingTime, setRemainingTime] = useState<number | null>(null); // ✅ countdown state
+
+  const lockDuration = 60; 
 
     const handleWalletStatusError = (errorCode: string, fallBackError: string | undefined = undefined, httpStatusCode: number | null = null) => {
         if (
@@ -55,21 +58,20 @@ export const PasscodePage: React.FC = () => {
                 setCanUnlockWallet(false);
                 setPasscode(initialPasscodeArray);
                 setConfirmPasscode(initialPasscodeArray);
+        if (errorCode === WalletLockStatus.TEMPORARILY_LOCKED) {
+          setRemainingTime(lockDuration); // start countdown immediately
+        }
             }
-        } else if (fallBackError) {
-            if (httpStatusCode === HTTP_STATUS_CODES.BAD_REQUEST) {
+    } else if (fallBackError && httpStatusCode === HTTP_STATUS_CODES.BAD_REQUEST) {
                 setError(t(fallBackError));
             }
-        }
-    }
+  };
 
     const handleCommonErrors = (response: ApiResult<any>, fallBackError: string | undefined = undefined) => {
-        if (response.error?.message === (NETWORK_ERROR_MESSAGE)) {
-            if (!navigator.onLine) {
-                setError(t("Common:error.networkError.message"));
-            } else {
-                setError(t("Common:error.unknownError.message"));
-            }
+    if (response.error?.message === NETWORK_ERROR_MESSAGE) {
+      setError(!navigator.onLine
+        ? t("Common:error.networkError.message")
+        : t("Common:error.unknownError.message"));
             return true;
         }
 
@@ -82,24 +84,21 @@ export const PasscodePage: React.FC = () => {
                 return true;
             default:
                 if (fallBackError) {
-                    setError(fallBackError)
-                    return true
-                }
+          setError(fallBackError);
+          return true;
         }
-        return false;
     }
+    return false;
+  };
 
     const fetchWallets = async () => {
         try {
-            const response = await walletsApi.fetchData({
-                apiConfig: api.fetchWallets,
-            })
-
+      const response = await walletsApi.fetchData({ apiConfig: api.fetchWallets });
 
             if (!response.ok()) {
                 console.error('Error occurred while fetching Wallets:', response.error);
                 handleCommonErrors(response, t('error.fetchWalletsError'));
-                return
+        return;
             }
 
             const wallets = response.data;
@@ -119,17 +118,28 @@ export const PasscodePage: React.FC = () => {
         void fetchWallets();
 
         const handleStorageChange = (e: StorageEvent) => {
-            if (e.key === 'walletId') {
+      if (e.key === 'walletId') 
                 void fetchWallets();
-            }
         };
 
         window.addEventListener('storage', handleStorageChange);
         return () => window.removeEventListener('storage', handleStorageChange);
-        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
-    const unlockWallet = async (walletId: string, pin: string) => {
+  // ✅ countdown effect
+  useEffect(() => {
+    if (!canUnlockWallet && remainingTime !== null) {
+      const interval = setInterval(() => {
+        setRemainingTime(prev =>
+          prev !== null && prev > 0 ? prev - 1 : 0
+        );
+      }, 1000);
+
+      return () => clearInterval(interval);
+    }
+  }, [canUnlockWallet, remainingTime]);
+
+  const unlockWallet = async (walletId: string | undefined, pin: string) => {
         if (!walletId) {
             console.error(`Wallet not found for Wallet Id: ${walletId}`);
             setError(t('error.walletNotFoundError'));
@@ -139,20 +149,18 @@ export const PasscodePage: React.FC = () => {
                 apiConfig: api.unlockWallet,
                 body: {walletPin: pin},
                 url: api.unlockWallet.url(walletId),
-            })
+      });
 
             if (!response.ok()) {
                 console.error("Error occurred while unlocking Wallet:", response.error);
                 const isErrorHandled = handleCommonErrors(response);
                 if (!isErrorHandled) {
-                    const errorCode = ((response.error as ApiError)?.response?.data as ErrorType).errorCode;
-                    handleWalletStatusError(errorCode, "error.incorrectPasscodeError", response.status);
-
-                    // Reset passcode field when incorrect passcode is entered
+          const errorCode = (response.error as ApiError)?.response?.data?.errorCode;
+          handleWalletStatusError(errorCode ?? "", "error.incorrectPasscodeError", response.status);
                     setPasscode(initialPasscodeArray);
                 }
             } else {
-                saveWalletId(walletId)
+        saveWalletId(walletId);
                 handleUnlockSuccess();
             }
         }
@@ -168,41 +176,45 @@ export const PasscodePage: React.FC = () => {
                 confirmWalletPin: confirmPasscode.join(''),
                 walletName: null
             },
-        })
+    });
 
         if (!response.ok()) {
             console.error("Error occurred while creating Wallet:", response.error);
-            const isErrorHandled = handleCommonErrors(response)
-            if(!isErrorHandled) {
-                const errorMessage = ((response.error as ApiError)?.response?.data as ErrorType).errorMessage ?? t('Common:error.unknownError.message');
+      const isErrorHandled = handleCommonErrors(response);
+      if (!isErrorHandled) {
+        let errorMessage: string;
+        if (response.error && 'response' in response.error) {
+          errorMessage = (response.error as ApiError)?.response?.data?.errorMessage
+            ?? t('Common:error.unknownError.message');
+        } else {
+          errorMessage = t('Common:error.unknownError.message');
+        }
                 setError(`${t('error.createWalletError')}: ${errorMessage}`);
             }
         } else {
             const createdWallet = response.data!;
             await unlockWallet(createdWallet.walletId, pin);
         }
-        
     };
 
     const handleUnlockSuccess = () => {
-        // If the user was asked to re-login due to an expired session, redirect them to the page they were trying to access
-        let redirectPath: string = ROUTES.USER_HOME
+    let redirectPath: string = ROUTES.USER_HOME;
         const storedRedirectPath = AppStorage.getItem(KEYS.REDIRECT_TO, true);
         if (storedRedirectPath) {
             redirectPath = storedRedirectPath!;
             AppStorage.removeItem(KEYS.REDIRECT_TO, true);
         }
         navigate(redirectPath);
-    }
+  };
 
     const handleSubmit = async () => {
-        setError('');
+    setError(null);
         setLoading(true);
 
         if (isUserCreatingWallet()) {
             await createWallet();
         } else {
-            const walletId = wallets ? wallets[0].walletId : undefined
+      const walletId = wallets ? wallets[0]?.walletId : undefined;
             const formattedPasscode = passcode.join('');
 
             if (formattedPasscode.length !== passcodeLength) {
@@ -231,7 +243,6 @@ export const PasscodePage: React.FC = () => {
                 passcode.join('') !== confirmPasscode.join('')) {
                 setError(t('error.passcodeMismatchError'));
             } 
-            // Clear error if either field is incomplete OR they match
             else if (passcode.includes('') || 
                      confirmPasscode.includes('') ||
                      passcode.join('') === confirmPasscode.join('')) {
@@ -249,54 +260,60 @@ export const PasscodePage: React.FC = () => {
                 ROUTES.USER_RESET_PASSCODE,
                 {
                     state: {
-                        walletId: wallets ? wallets[0].walletId : undefined
-                    }
-                }
-            );
+          walletId: wallets ? wallets[0]?.walletId : undefined 
+        },
+      });
 
-        return <div className={PasscodePageStyles.forgotPasscodeContainer}>
+    return ( <div className={PasscodePageStyles.forgotPasscodeContainer}>
             <TertiaryButton onClick={handleForgotPasscode} title={t('forgotPasscode') + "?"}
                             testId={"forgot-passcode"} className={PasscodePageStyles.forgotPasscodeButton}/>
-        </div>;
+      </div>
+    );
     }
 
-    function renderPasscodeInput(label: string, value: string[], onChange: (values: string[]) => void, testId: string) {
-        return <PasscodeInput label={label} value={value} onChange={onChange} testId={testId}
-                              disabled={!canUnlockWallet}/>;
+  function renderPasscodeInput(label: string, value: string[], onChange: (values: string[]) => void, testId: string){
+    return (<PasscodeInput label={label} value={value} onChange={onChange}testId={testId}
+        disabled={!canUnlockWallet}/>
+      );
     }
 
-    const renderContent = () => {
-        return (
+  const renderContent = () => (
             <div className={PasscodePageStyles.contentContainer}>
-                {wallets &&
+      {wallets && (
                     <Fragment>
-                        {<div className={PasscodePageStyles.inputWrapper}>
+          <div className={PasscodePageStyles.inputWrapper}>
                             {renderPasscodeInput(t('enterPasscodeLabel'), passcode, setPasscode, "passcode")}
-
                             {isUserCreatingWallet() &&
-                                renderPasscodeInput(t('confirmPasscodeLabel'), confirmPasscode, setConfirmPasscode, "confirm-passcode")
-                            }
+            renderPasscodeInput(t('confirmPasscodeLabel'),confirmPasscode,setConfirmPasscode,"confirm-passcode")}
+          </div>
+
+          {!isUserCreatingWallet() && renderForgotPasscodeButton()}
+
+          {/* ✅ Countdown display */}
+          {!canUnlockWallet && remainingTime !== null && (
+            <div className={PasscodePageStyles.lockCountdown}>
+              {remainingTime > 0
+                ? `Locked. Try again in ${Math.floor(remainingTime / 60)}:${(
+                    remainingTime % 60
+                  ).toString().padStart(2, '0')}`
+                : "Lock expired, you can try again."}
                         </div>
-                        }
-                        {
-                            !isUserCreatingWallet() && renderForgotPasscodeButton()
-                        }
+          )}
+
                         <div className={PasscodePageStyles.buttonContainer}>
                             <SolidButton
                                 fullWidth={true}
                                 testId="btn-submit-passcode"
                                 onClick={handleSubmit}
                                 title={loading ? t('submitting') : t('submit')}
-                                disabled={isButtonDisabled}
+              disabled={isButtonDisabled || !canUnlockWallet}
                                 className={isButtonDisabled ? PasscodePageStyles.disabledButton : ''}
                             />
                         </div>
                     </Fragment>
-                }
-
+      )}
             </div>
         );
-    };
 
     return (
         <PasscodePageTemplate

--- a/inji-web/src/pages/User/Passcode/PasscodePageStyles.ts
+++ b/inji-web/src/pages/User/Passcode/PasscodePageStyles.ts
@@ -4,5 +4,6 @@ export const PasscodePageStyles = {
   forgotPasscodeContainer: "w-full mx-auto flex justify-start sm:mb-2 mb-1",
   forgotPasscodeButton: "text-sm md:text-md font-semibold",
   buttonContainer: "w-full",
-  disabledButton: "grayscale"
+  disabledButton: "grayscale",
+  lockCountdown: "text-center text-red-600 font-semibold mt-2" // NEW
 };


### PR DESCRIPTION
## Description
- The countdown now starts immediately when the wallet is temporarily locked.
- No refresh is required — the timer updates live in the UI.

## Changes
 updated passcodepage.tsx and passcodepagestyles.tsx

## Issue ticket number and Link
InjiWeb-1683 (https://mosip.atlassian.net/browse/INJIWEB-1683)

## Video     
Uploading INJIWEB-1683.mp4…

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added countdown timer display when account is temporarily locked after failed passcode attempts.
  * Submit button now disabled during lockout period.

* **Bug Fixes**
  * Improved error handling for network-related issues.
  * Enhanced wallet data validation and safer error message extraction.

* **Style**
  * Added styling for lockout countdown display.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->