### PR TITLE
INJIWEB-1640 Fix mobile sidebar default open state after login

### DIFF
--- a/inji-web/src/components/User/Sidebar.tsx
+++ b/inji-web/src/components/User/Sidebar.tsx
@@ -84,10 +84,17 @@ type SidebarProps = {
     forceLeftPosition?: boolean;
 };
 
+const MOBILE_BREAKPOINT_PX = 640; // Matches Tailwind 'sm' – below this is mobile
+
+function getInitialSidebarCollapsed(): boolean {
+    if (typeof window === 'undefined') return false;
+    return window.innerWidth < MOBILE_BREAKPOINT_PX;
+}
+
 export const Sidebar: React.FC<SidebarProps> = ({ disabled = false, forceLeftPosition = false }) => {
     const {t} = useTranslation('User');
     const location = useLocation();
-    const [isCollapsed, setIsCollapsed] = useState(false);
+    const [isCollapsed, setIsCollapsed] = useState(getInitialSidebarCollapsed);
     const language = useSelector((state: RootState) => state.common.language);
 
     const toggleSidebar = () => {


### PR DESCRIPTION
Initialize the sidebar collapsed on mobile viewports so that, after login,
users land on the home screen with the sidebar closed by default, while
keeping the existing behavior (open by default) on larger screens.

https://github.com/user-attachments/assets/87ba564d-1c96-4272-a227-9ca5d7f6b4f6



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The sidebar now automatically collapses when viewing the app on mobile devices, adapting to screen size on page load.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->