### PR TITLE
Remove PROJECT_KEY from Sonar analysis workflow

### DIFF
--- a/.github/workflows/push-trigger.yml
+++ b/.github/workflows/push-trigger.yml
@@ -72,7 +72,6 @@ jobs:
     with:
       SERVICE_LOCATION: ./inji-web
       SONAR_URL: 'https://sonarcloud.io'
-      PROJECT_KEY: 'inji_inji-web'
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       ORG_KEY: ${{ secrets.ORG_KEY }}


### PR DESCRIPTION
Remove PROJECT_KEY from npm-sonar-analysis.yml workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined CI/CD workflow configuration to streamline the continuous integration pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->