### PR TITLE
[INJIWEB-1848] - update csrf ignore urls inji-web docker setup

### DIFF
--- a/docker-compose/config/mimoto-default.properties
+++ b/docker-compose/config/mimoto-default.properties
@@ -96,8 +96,13 @@ mosip.partner.encryption.key=123456
 # Property which indicates whether the data includes its thumbprint (a unique hash for integrity verification) or not
 mosip.partner.prependThumbprint=true
 
-# Property which defines whether protection against Cross-Site Request Forgery (CSRF) attacks should be enabled or disabled
-csrf.disabled=true
+# CSRF Security Configuration
+# CSRF protection is always enabled by default. State-changing requests (POST, PUT, DELETE, PATCH)
+# require a valid CSRF token to be sent in the X-XSRF-TOKEN header.
+# List of URLs that are excluded from CSRF protection. These URLs can still require authentication.
+# OAuth2 endpoints and public endpoints are typically excluded from CSRF protection.
+mosip.security.csrf-ignore-urls=/oauth2/**,/logout,/safetynet/**,/credentials/**,/credentialshare/**,/binding-otp,/wallet-binding,\
+  /get-token/**,/req/otp,/vid,/req/auth/**,/req/individualId/otp,/auth/*/token-login
 
 #-------------TOKEN GENERATION----------------
 #Token generation request id


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CSRF protection is now enabled by default to defend against Cross-Site Request Forgery attacks
  * Specific application endpoints have been configured as exempt from CSRF verification while maintaining security for other operations

* **Chores**
  * Updated security configuration settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->