### PR TITLE
[INJIWEB-1841] - Update issuers API to v2 paths (/v2/issuers)

### DIFF
--- a/inji-web/src/__tests__/utils/api.test.tsx
+++ b/inji-web/src/__tests__/utils/api.test.tsx
@@ -47,7 +47,7 @@ describe('Testing API Class', () => {
 
   test('Check fetchIssuers request', () => {
     const fetchIssuers: ApiRequest = apiModule.api.fetchIssuers;
-    expect(fetchIssuers.url()).toBe('https://api.collab.mossip.net/v1/mimoto/issuers');
+    expect(fetchIssuers.url()).toBe('https://api.collab.mossip.net/v1/mimoto/v2/issuers');
     expect(fetchIssuers.methodType).toBe(apiModule.MethodType.GET);
     expect(fetchIssuers.headers()).toEqual({
       'Content-Type': 'application/json'
@@ -57,7 +57,7 @@ describe('Testing API Class', () => {
   test('Check fetchSpecificIssuer request', () => {
     const issuerId = '123';
     const fetchSpecificIssuer: ApiRequest = apiModule.api.fetchSpecificIssuer;
-    expect(fetchSpecificIssuer.url(issuerId)).toBe('https://api.collab.mossip.net/v1/mimoto/issuers/123');
+    expect(fetchSpecificIssuer.url(issuerId)).toBe('https://api.collab.mossip.net/v1/mimoto/v2/issuers/123');
     expect(fetchSpecificIssuer.methodType).toBe(apiModule.MethodType.GET);
     expect(fetchSpecificIssuer.headers()).toEqual({
       'Content-Type': 'application/json'

--- a/inji-web/src/utils/api.ts
+++ b/inji-web/src/utils/api.ts
@@ -24,7 +24,7 @@ export class api {
     static authorizationRedirectionUrl = window.location.origin + ROUTES.REDIRECT;
 
     static fetchIssuers: ApiRequest = {
-        url: () => api.mimotoHost + "/issuers",
+        url: () => api.mimotoHost + "/v2/issuers",
         methodType: MethodType.GET,
         headers: () => {
             return {
@@ -33,7 +33,7 @@ export class api {
         }
     };
     static fetchSpecificIssuer: ApiRequest = {
-        url: (issuerId: string) => api.mimotoHost + `/issuers/${issuerId}`,
+        url: (issuerId: string) => api.mimotoHost + `/v2/issuers/${issuerId}`,
         methodType: MethodType.GET,
         headers: () => {
             return {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated issuer-related API endpoints to use versioned path structure for improved API compatibility and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->