### PR TITLE
[INJIWEB-1823] - Update issuer to Mock ID for docker-compose setup

### DIFF
--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -187,7 +187,7 @@ The mimoto-issuers-config.json file defines the list of Credential Issuers that 
       "wellknown_endpoint": "https://injicertify-mock.collab.mosip.net/v1/certify/issuance/.well-known/openid-credential-issuer",
       "redirect_uri": "io.mosip.residentapp.inji://oauthredirect",
       "authorization_audience": "https://esignet-mock.collab.mosip.net/v1/esignet/oauth/v2/token",
-      "token_endpoint": "https://api.collab.mosip.net/v1/mimoto/get-token/Mock",
+      "token_endpoint": "https://localhost:8099/v1/mimoto/get-token/Mock",
       "proxy_token_endpoint": "https://esignet-mock.collab.mosip.net/v1/esignet/oauth/v2/token",
       "client_alias": "wallet-demo-client",
       "qr_code_type": "OnlineSharing",

--- a/docker-compose/config/mimoto-issuers-config.json
+++ b/docker-compose/config/mimoto-issuers-config.json
@@ -19,7 +19,7 @@
       "wellknown_endpoint": "https://injicertify-mock.collab.mosip.net/v1/certify/issuance/.well-known/openid-credential-issuer",
       "redirect_uri": "io.mosip.residentapp.inji://oauthredirect",
       "authorization_audience": "https://esignet-mock.collab.mosip.net/v1/esignet/oauth/v2/token",
-      "token_endpoint": "https://api.collab.mosip.net/v1/mimoto/get-token/Mock",
+      "token_endpoint": "https://localhost:8099/v1/mimoto/get-token/Mock",
       "proxy_token_endpoint": "https://esignet-mock.collab.mosip.net/v1/esignet/oauth/v2/token",
       "client_alias": "wallet-demo-client",
       "qr_code_type": "OnlineSharing",


### PR DESCRIPTION
Update issuer to Mock ID in mimoto-issuers-config
Update Readme with Mock ID issuer example

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated issuer configuration guidance to reflect the new Mock issuer and OpenId4VCI support; added reference to mock data and a note about sample UINs in customization docs.

* **Chores**
  * Replaced previous issuer details with Mock issuer endpoints, display metadata, and token/client settings in configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->