### PR TITLE
[INJIWEB-00] Update SD-JWT OVP design doc by adding public claims in a separate field in matching API response and presentation submission response 

### DIFF
--- a/docs/SDJWTOpenID4VPIntegrationGuide.md
+++ b/docs/SDJWTOpenID4VPIntegrationGuide.md
@@ -110,7 +110,8 @@ sequenceDiagram
         "credentialTypeDisplayName": "SD-JWT VC",
         "credentialTypeLogo": "https://mosip.github.io/inji-config/logos/mosipid-logo.png",
         "format": "vc+sd-jwt",
-        "sdClaims": ["name", "age", "gender"]
+        "claims": [ "$.name", "$.id", "$.address.country.name" ],
+        "sdClaims": [ "$.age", "$.gender", "$.address.line1", "$.address.line2", "$.address.country.code" ]
       }
     ],
     "missingClaims": [
@@ -136,7 +137,7 @@ sequenceDiagram
   {
     "selectedCredentials": ["cred-123", "cred-456"],
     "selectedSdClaims": {
-      "cred-123": ["name", "age"]
+      "cred-123": ["$.age", "$.gender", "$.address.line1"]
     }
   }
   ```

--- a/docs/SDJWTOpenID4VPIntegrationGuide.md
+++ b/docs/SDJWTOpenID4VPIntegrationGuide.md
@@ -120,7 +120,7 @@ sequenceDiagram
   }
   ```
 
-  **Note:** `sdClaims` will hold disclosures available in the sd-jwt.
+  **Note:** `sdClaims` will hold field's JSON path for which disclosures available in the sd-jwt VC and `claims` will hold the public claims.
 
 #### Step 25 : Selection of credentials and submission
 


### PR DESCRIPTION
Update SD-JWT OVP design doc by adding public claims in a separate field in matching API response and presentation submission response. The `claims` and `sdClaims` will hold JSON paths of the fields.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated credential examples to use JSONPath-based selectors for referencing claims and disclosure fields.
  * Clarified definitions of public claims versus fields for selective disclosures in credential metadata.
  * Revised credential selection examples to demonstrate proper JSON path syntax for field references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->