### PR TITLE
INJIWEB-1834: Fix double scrollbar in View Card modal

### DIFF
--- a/inji-web/src/modals/ModalStyles.ts
+++ b/inji-web/src/modals/ModalStyles.ts
@@ -16,7 +16,7 @@ export const ModalStyles = {
         },
         separator: "flex-shrink-0",
         content: {
-            wrapper: "flex flex-col flex-1 relative sm:bg-transparent bg-white sm:mb-4 pb-0 min-h-0",
+            wrapper: "flex flex-col flex-1 relative sm:bg-transparent bg-white sm:mb-4 pb-0 min-h-0 overflow-hidden",
             container: "overflow-y-auto flex-1 min-h-0 sm:mx-5 sm:m-0 m-2 sm:bg-transparent bg-white sm:rounded-none rounded-xl"
         },
         action: "sm:absolute sm:right-6 sm:bottom-0 sm:mr-10 sm:pb-8 sm:bg-transparent sm:w-auto static bg-white flex px-2 w-full py-2 sm:rounded-b-lg"


### PR DESCRIPTION

Fixes the issue where double scrollbars were appearing in the View Card screen.

Changes made:
- Added overflow-hidden to parent wrapper in ModalStyles
- Ensured only one container has scroll

Testing:
- Tested locally in Chrome
- Verified by resizing window and changing screen resolutions
- Only one scrollbar is visible

Note:
- Issue observed mainly on Windows Chrome/Edge
- Preventive fix applied

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved modal content overflow handling by containing overflowing content within modal boundaries (prevents content spill and ensures stable layout and scrolling behavior).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->