### PR TITLE
Injiweb 1834- fixed the double scroll bar issue 

### DIFF
--- a/inji-web/src/__tests__/components/Common/Preview/__snapshots__/PDFViewer.test.tsx.snap
+++ b/inji-web/src/__tests__/components/Common/Preview/__snapshots__/PDFViewer.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`PDFViewer Component renders correctly and matches snapshot 1`] = `
 <div>
   <div
-    class="w-full max-h-screen relative flex flex-col items-center overflow-auto"
+    class="w-full max-h-screen relative flex flex-col items-center"
   >
     <div
       data-file="\\"blob:http://localhost:3000/mock-pdf-url\\""

--- a/inji-web/src/components/Preview/PDFViewerStyles.ts
+++ b/inji-web/src/components/Preview/PDFViewerStyles.ts
@@ -1,4 +1,4 @@
 export const PDFViewerStyles = {
-    'container': 'w-full max-h-screen relative flex flex-col items-center overflow-auto',
+    'container': 'w-full max-h-screen relative flex flex-col items-center',
     'pageWrapper': 'mb-2 border border-gray-200'
 };

--- a/inji-web/src/modals/ModalStyles.ts
+++ b/inji-web/src/modals/ModalStyles.ts
@@ -16,7 +16,7 @@ export const ModalStyles = {
         },
         separator: "flex-shrink-0",
         content: {
-            wrapper: "flex flex-col flex-1 relative sm:bg-transparent bg-white sm:mb-4 pb-0 min-h-0 overflow-hidden",
+            wrapper: "flex flex-col flex-1 relative sm:bg-transparent bg-white sm:mb-4 pb-0 min-h-0",
             container: "overflow-y-auto flex-1 min-h-0 sm:mx-5 sm:m-0 m-2 sm:bg-transparent bg-white sm:rounded-none rounded-xl"
         },
         action: "sm:absolute sm:right-6 sm:bottom-0 sm:mr-10 sm:pb-8 sm:bg-transparent sm:w-auto static bg-white flex px-2 w-full py-2 sm:rounded-b-lg"


### PR DESCRIPTION
reverted the previous commit 
Added fix in PDFviewersStyles.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Style

* Adjusted PDF viewer container scrolling and display behavior
* Enhanced modal content area overflow handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->