### PR TITLE
[INJIWEB-1891] - Update issuers config to Mock ID, add v2 endpoints to ignore auth urls

### DIFF
--- a/docker-compose/config/mimoto-default.properties
+++ b/docker-compose/config/mimoto-default.properties
@@ -412,7 +412,7 @@ spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 # List of URLs that can be accessed without any user authentication by Identity Provider
 mosip.security.ignore-auth-urls=/safetynet/**,/actuator/**,/swagger-ui/**,/v3/api-docs/**,\
   /allProperties,/credentials/**,/credentialshare/**,/binding-otp,/wallet-binding,/get-token/**,\
-  /issuers,/issuers/**,/authorize,/req/otp,/vid,/req/auth/**,/req/individualId/otp,/aid/get-individual-id,\
+  /issuers,/issuers/**,/v2/issuers,/v2/issuers/**,/authorize,/req/otp,/vid,/req/auth/**,/req/individualId/otp,/aid/get-individual-id,\
  /verifiers, /auth/*/token-login
 
 # Inji mobile wallet configuration

--- a/docker-compose/config/mimoto-issuers-config.json
+++ b/docker-compose/config/mimoto-issuers-config.json
@@ -16,7 +16,7 @@
         }
       ],
       "client_id": "wallet-demo",
-      "token_endpoint": "https://api.collab.mosip.net/v1/mimoto/get-token/Mock",
+      "token_endpoint": "https://localhost:8099/v1/mimoto/get-token/Mock",
       "client_alias": "wallet-demo-client",
       "qr_code_type": "OnlineSharing",
       "enabled": "true",

--- a/docker-compose/config/mimoto-issuers-config.json
+++ b/docker-compose/config/mimoto-issuers-config.json
@@ -16,15 +16,10 @@
         }
       ],
       "client_id": "wallet-demo",
-      "wellknown_endpoint": "https://injicertify-mock.collab.mosip.net/v1/certify/issuance/.well-known/openid-credential-issuer",
-      "redirect_uri": "io.mosip.residentapp.inji://oauthredirect",
-      "authorization_audience": "https://esignet-mock.collab.mosip.net/v1/esignet/oauth/v2/token",
       "token_endpoint": "https://api.collab.mosip.net/v1/mimoto/get-token/Mock",
-      "proxy_token_endpoint": "https://esignet-mock.collab.mosip.net/v1/esignet/oauth/v2/token",
       "client_alias": "wallet-demo-client",
       "qr_code_type": "OnlineSharing",
       "enabled": "true",
-      "credential_issuer": "Mock",
       "credential_issuer_host": "https://injicertify-mock.collab.mosip.net"
     }
   ]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated API endpoint authentication configuration to allow unauthenticated public access to new V2 issuer API endpoints alongside existing issuer endpoints, expanding the range of publicly accessible endpoints.
  * Removed five credential-related configuration fields from the Mock issuer configuration, including well-known endpoint, redirect URI, authorization audience, proxy token endpoint, and credential issuer fields, reducing overall configuration complexity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->