### PR TITLE
[INJIWEB-1883] Update helm chart versions in deployment scripts and docker images

### DIFF
--- a/deploy/inji-web-uitestrig/install.sh
+++ b/deploy/inji-web-uitestrig/install.sh
@@ -7,7 +7,7 @@ if [ $# -ge 1 ] ; then
 fi
 
 NS=injiweb-ui-testrig
-CHART_VERSION=0.0.1-develop
+CHART_VERSION=1.4.1
 COPY_UTIL=../copy_cm_func.sh
 
 echo Create $NS namespace

--- a/deploy/inji-web-uitestrig/install.sh
+++ b/deploy/inji-web-uitestrig/install.sh
@@ -7,7 +7,7 @@ if [ $# -ge 1 ] ; then
 fi
 
 NS=injiweb-ui-testrig
-CHART_VERSION=1.4.1
+CHART_VERSION=1.5.0
 COPY_UTIL=../copy_cm_func.sh
 
 echo Create $NS namespace

--- a/deploy/inji-web-uitestrig/values.yaml
+++ b/deploy/inji-web-uitestrig/values.yaml
@@ -28,8 +28,8 @@ modules:
     enabled: true
     image:
       registry: docker.io
-      repository: injistackdev/uitest-web
-      tag: develop
+      repository: injistackqa/uitest-web
+      tag: 0.17.x
       pullPolicy: Always
 
 crontime: "0 3 * * *"    ## run cronjob every day at 3 AM (time hr: 0-23 )

--- a/deploy/inji-web/install.sh
+++ b/deploy/inji-web/install.sh
@@ -7,7 +7,7 @@ if [ $# -ge 1 ] ; then
 fi
 
 NS=injiweb
-CHART_VERSION=0.0.1-develop
+CHART_VERSION=0.17.0-develop
 
 DEFAULT_INJIWEB_HOST=$( kubectl get cm inji-stack-config -n config-server -o jsonpath={.data.injiweb-host} )
 # Check if INJIWEB_HOST is present under configmap/inji-stack-config of configserver

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -41,7 +41,7 @@ services:
 
   mimoto-service:
     container_name: 'mimoto-service'
-    image: 'injistackdev/mimoto:develop'
+    image: 'injistackqa/mimoto:0.22.x'
     user: root
     ports:
       - "8099:8099"
@@ -67,7 +67,7 @@ services:
 
   inji-web:
     container_name: 'inji-web'
-    image: 'injistackdev/inji-web:develop'
+    image: 'injistackqa/inji-web:0.17.x'
     ports:
       - '3004:3004'
     environment:

--- a/helm/inji-web/values.yaml
+++ b/helm/inji-web/values.yaml
@@ -51,8 +51,8 @@ service:
 
 image:
   registry: docker.io
-  repository: injistackdev/inji-web
-  tag: develop
+  repository: injistackqa/inji-web
+  tag: 0.17.x
 
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'


### PR DESCRIPTION
Update helm chart versions in deployment scripts and docker images in docker-compose file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Helm chart versions used for deployments (inji-web-uitestrig → 1.5.0; inji-web installer → 0.17.0-develop).
  * Updated container image sources and tags to QA builds: inji-web → 0.17.x, mimoto-service → 0.22.x, and related deployment values updated to use QA repositories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->