### PR TITLE
Ifix(injiweb): #623 Language selection updates on first click

### DIFF
--- a/inji-web/src/__tests__/components/Common/Preview/__snapshots__/PDFViewer.test.tsx.snap
+++ b/inji-web/src/__tests__/components/Common/Preview/__snapshots__/PDFViewer.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`PDFViewer Component renders correctly and matches snapshot 1`] = `
 <div>
   <div
-    class="w-full max-h-screen relative flex flex-col items-center overflow-auto"
+    class="w-full max-h-screen relative flex flex-col items-center"
   >
     <div
       data-file="\\"blob:http://localhost:3000/mock-pdf-url\\""

--- a/inji-web/src/components/Common/LanguageSelector.tsx
+++ b/inji-web/src/components/Common/LanguageSelector.tsx
@@ -15,8 +15,8 @@ export const LanguageSelector: React.FC<{ "data-testid"?: string }> = ({ "data-t
     const [isOpen, setIsOpen] = useState(false);
 
 
-    const handleChange = (lang: string) => {
-    switchLanguage(lang);
+    const handleChange = async (lang: string) => {
+    await switchLanguage(lang);
     dispatch(storeLanguage(lang));
     setIsOpen(false);
 }

--- a/inji-web/src/components/Common/LanguageSelector.tsx
+++ b/inji-web/src/components/Common/LanguageSelector.tsx
@@ -14,20 +14,20 @@ export const LanguageSelector: React.FC<{ "data-testid"?: string }> = ({ "data-t
     language = language ?? window._env_.DEFAULT_LANG;
     const [isOpen, setIsOpen] = useState(false);
 
-    interface DropdownItem {
-        label: string;
-        value: string;
-    }
 
-    const handleChange = (item: DropdownItem) => {
-        setIsOpen(false);
-        switchLanguage(item.value);
-        dispatch(storeLanguage(item.value));
-    }
+    const handleChange = (lang: string) => {
+    switchLanguage(lang);
+    dispatch(storeLanguage(lang));
+    setIsOpen(false);
+}
 
     return <div className={"flex flex-row justify-center items-center"}
                 data-testid={testId ?? "LanguageSelector-Outer-Div"} 
-                onBlur={()=>setIsOpen(false)}
+                onBlur={(e) => {
+    if (!e.currentTarget.contains(e.relatedTarget)) {
+        setIsOpen(false);
+    }
+}}
                 tabIndex={0}
                 role="button">
         
@@ -37,7 +37,10 @@ export const LanguageSelector: React.FC<{ "data-testid"?: string }> = ({ "data-t
                 type="button"
                 className="flex flex-row items-center w-full h-[3rem] px-2 rounded-xl border border-gray-200 bg-white shadow-sm font-semibold focus:outline-none"
                 data-testid={"Language-Selector-Button"}
-                onMouseDown={() => setIsOpen(open => !isOpen)}>
+                onClick={(e) => {
+    e.stopPropagation();
+    setIsOpen(open => !open);
+}}>
             
                 <GradientWrapper>
                     <VscGlobe
@@ -65,7 +68,11 @@ export const LanguageSelector: React.FC<{ "data-testid"?: string }> = ({ "data-t
                                         ${language === item.value
                                         ? "bg-iw-dropdownActiveBg text-iw-primary font-semibold"
                                         : "text-iw-dropdownText hover:bg-iw-dropdownActiveBg hover:text-iw-primary"} transition-colors`}
-                                    onMouseDown={(event) => {event.stopPropagation();handleChange(item)}}>
+                                    onClick={(event) => {
+    event.stopPropagation();
+    handleChange(item.value);
+}}
+>
                                     {language === item.value ? <span className="text-iw-primary font-semibold">{item.label}</span> : item.label}
                                     {language === item.value && <FaCheck className="text-iw-primary" /> }
                                 </button>

--- a/inji-web/src/components/Preview/PDFViewerStyles.ts
+++ b/inji-web/src/components/Preview/PDFViewerStyles.ts
@@ -1,4 +1,4 @@
 export const PDFViewerStyles = {
-    'container': 'w-full max-h-screen relative flex flex-col items-center overflow-auto',
+    'container': 'w-full max-h-screen relative flex flex-col items-center',
     'pageWrapper': 'mb-2 border border-gray-200'
 };

--- a/inji-web/src/modals/ModalStyles.ts
+++ b/inji-web/src/modals/ModalStyles.ts
@@ -16,7 +16,7 @@ export const ModalStyles = {
         },
         separator: "flex-shrink-0",
         content: {
-            wrapper: "flex flex-col flex-1 relative sm:bg-transparent bg-white sm:mb-4 pb-0 min-h-0 overflow-hidden",
+            wrapper: "flex flex-col flex-1 relative sm:bg-transparent bg-white sm:mb-4 pb-0 min-h-0",
             container: "overflow-y-auto flex-1 min-h-0 sm:mx-5 sm:m-0 m-2 sm:bg-transparent bg-white sm:rounded-none rounded-xl"
         },
         action: "sm:absolute sm:right-6 sm:bottom-0 sm:mr-10 sm:pb-8 sm:bg-transparent sm:w-auto static bg-white flex px-2 w-full py-2 sm:rounded-b-lg"


### PR DESCRIPTION
### What does this PR do?

Fixes the issue where language selection in InjiWeb required a double click to apply changes. The language now updates immediately on the first click.

---

### Related Issue

Closes #623

---

### Type of Change

* fix - bug fix in frontend language selector

---

### Summary

* Fixed event handling in language dropdown
* Prevented unwanted event propagation using `event.stopPropagation()`
* Improved dropdown toggle logic using functional state update
* Fixed `onBlur` behavior to avoid premature dropdown closing
* Ensured language state updates correctly on first click

---

### Testing

* Verified locally on `http://localhost:3004`
* Language changes correctly on first click
* No regressions observed

---

### Impact

* Improves user experience
* Fixes incorrect UI behavior
* No backend impact


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved language selector dropdown interactions and focus behavior for more reliable language switching.
  * Enhanced language selection persistence using default language configuration.

* **Style**
  * Refined PDF viewer layout and display properties.
  * Updated modal header styling for improved content visibility and layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->