### PR TITLE
fix(injiweb): #623 Language selection updates on first click

### DIFF
--- a/inji-web/src/components/Common/LanguageSelector.tsx
+++ b/inji-web/src/components/Common/LanguageSelector.tsx
@@ -14,20 +14,20 @@ export const LanguageSelector: React.FC<{ "data-testid"?: string }> = ({ "data-t
     language = language ?? window._env_.DEFAULT_LANG;
     const [isOpen, setIsOpen] = useState(false);
 
-    interface DropdownItem {
-        label: string;
-        value: string;
-    }
 
-    const handleChange = (item: DropdownItem) => {
-        setIsOpen(false);
-        switchLanguage(item.value);
-        dispatch(storeLanguage(item.value));
-    }
+    const handleChange = async (lang: string) => {
+    await switchLanguage(lang);
+    dispatch(storeLanguage(lang));
+    setIsOpen(false);
+}
 
     return <div className={"flex flex-row justify-center items-center"}
                 data-testid={testId ?? "LanguageSelector-Outer-Div"} 
-                onBlur={()=>setIsOpen(false)}
+                onBlur={(e) => {
+    if (!e.currentTarget.contains(e.relatedTarget)) {
+        setIsOpen(false);
+    }
+}}
                 tabIndex={0}
                 role="button">
         
@@ -37,7 +37,10 @@ export const LanguageSelector: React.FC<{ "data-testid"?: string }> = ({ "data-t
                 type="button"
                 className="flex flex-row items-center w-full h-[3rem] px-2 rounded-xl border border-gray-200 bg-white shadow-sm font-semibold focus:outline-none"
                 data-testid={"Language-Selector-Button"}
-                onMouseDown={() => setIsOpen(open => !isOpen)}>
+               onMouseDown={(e) => {
+    e.stopPropagation();
+    setIsOpen(open => !open);
+}}>
             
                 <GradientWrapper>
                     <VscGlobe
@@ -65,7 +68,11 @@ export const LanguageSelector: React.FC<{ "data-testid"?: string }> = ({ "data-t
                                         ${language === item.value
                                         ? "bg-iw-dropdownActiveBg text-iw-primary font-semibold"
                                         : "text-iw-dropdownText hover:bg-iw-dropdownActiveBg hover:text-iw-primary"} transition-colors`}
-                                    onMouseDown={(event) => {event.stopPropagation();handleChange(item)}}>
+                                    onClick={(event) => {
+    event.stopPropagation();
+    handleChange(item.value);
+}}
+>
                                     {language === item.value ? <span className="text-iw-primary font-semibold">{item.label}</span> : item.label}
                                     {language === item.value && <FaCheck className="text-iw-primary" /> }
                                 </button>


### PR DESCRIPTION
### What does this PR do?

Fixes the issue where language selection in InjiWeb required a double click to apply changes.
Now, the language updates immediately on the first click.

---

### Related Issue

Closes #623

---

### Type of Change

* fix - bug fix in language selector

---

### Summary

* Fixed event handling in dropdown
* Prevented unwanted event propagation
* Improved state handling using async/await
* Ensured language updates correctly on first click

---

### Testing

* Verified locally on http://localhost:3004/
* Language updates on single click
* No regressions observed

---

### Impact

* Improves user experience
* No backend changes