### PR TITLE
fix:return access_denied for no matching credential

### DIFF
--- a/inji-web/src/__tests__/modals/NoMatchingCredentialsModal.test.tsx
+++ b/inji-web/src/__tests__/modals/NoMatchingCredentialsModal.test.tsx
@@ -246,7 +246,7 @@ describe('NoMatchingCredentialsModal', () => {
                     apiConfig: expect.any(Object),
                     body: {
                         errorCode: 'access_denied',
-                        errorMessage: 'No matching credentials available to satisfy the presentation request.',
+                        errorMessage: 'No matching credentials found to fulfill the request.',
                     },
                 });
             });
@@ -277,7 +277,7 @@ describe('NoMatchingCredentialsModal', () => {
                     apiConfig: expect.any(Object),
                     body: {
                         errorCode: 'access_denied',
-                        errorMessage: 'No matching credentials available to satisfy the presentation request.',
+                        errorMessage: 'No matching credentials found to fulfill the request.',
                     },
                 });
             });

--- a/inji-web/src/__tests__/modals/NoMatchingCredentialsModal.test.tsx
+++ b/inji-web/src/__tests__/modals/NoMatchingCredentialsModal.test.tsx
@@ -244,7 +244,10 @@ describe('NoMatchingCredentialsModal', () => {
                 expect(mockFetchData).toHaveBeenCalledWith({
                     url: expect.stringContaining('/presentations/test-presentation-id'),
                     apiConfig: expect.any(Object),
-                    body: { errorCode: 'invalid_transaction_data', errorMessage: 'No matching credentials found to fulfill the request'},
+                    body: {
+                        errorCode: 'access_denied',
+                        errorMessage: 'No matching credentials available to satisfy the presentation request.',
+                    },
                 });
             });
             expect(window.location.href).toBe('https://example.com/redirect');
@@ -272,7 +275,10 @@ describe('NoMatchingCredentialsModal', () => {
                 expect(mockFetchData).toHaveBeenCalledWith({
                     url: expect.stringContaining('/presentations/test-presentation-id'),
                     apiConfig: expect.any(Object),
-                    body: { errorCode: 'invalid_transaction_data', errorMessage: 'No matching credentials found to fulfill the request' },
+                    body: {
+                        errorCode: 'access_denied',
+                        errorMessage: 'No matching credentials available to satisfy the presentation request.',
+                    },
                 });
             });
             expect(window.location.href).toBe('https://example.com/redirect');

--- a/inji-web/src/modals/NoMatchingCredentialsModal.tsx
+++ b/inji-web/src/modals/NoMatchingCredentialsModal.tsx
@@ -49,7 +49,7 @@ export const NoMatchingCredentialsModal: React.FC<NoMatchingCredentialsModalProp
     const rejectVerifierCallback = useCallback(async () => {
         const rejectPayload = {
             errorCode: "access_denied",
-            errorMessage: "No matching credentials available to satisfy the presentation request."
+            errorMessage: "No matching credentials found to fulfill the request."
         };
 
         const response = await rejectVerifier({

--- a/inji-web/src/modals/NoMatchingCredentialsModal.tsx
+++ b/inji-web/src/modals/NoMatchingCredentialsModal.tsx
@@ -48,8 +48,8 @@ export const NoMatchingCredentialsModal: React.FC<NoMatchingCredentialsModalProp
 
     const rejectVerifierCallback = useCallback(async () => {
         const rejectPayload = {
-            errorCode: "invalid_transaction_data",
-            errorMessage: "No matching credentials found to fulfill the request"
+            errorCode: "access_denied",
+            errorMessage: "No matching credentials available to satisfy the presentation request."
         };
 
         const response = await rejectVerifier({


### PR DESCRIPTION
Closes #642

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized and clarified error messaging when a verifier rejection occurs. Users now see a clearer, consistent message stating that no matching credentials were found to fulfill the request, improving guidance during credential presentation and authentication.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/inji/inji-web/pull/643?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->