### PR TITLE
fix(language-selector): reopen dropdown on first click after language change

### DIFF
--- a/inji-web/src/__tests__/components/Common/LanguageSelector.test.tsx
+++ b/inji-web/src/__tests__/components/Common/LanguageSelector.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { screen, fireEvent } from '@testing-library/react';
+import { screen, fireEvent, within } from '@testing-library/react';
 import { LanguageSelector } from '../../../components/Common/LanguageSelector';
 import { mockCrypto, renderWithProvider } from '../../../test-utils/mockUtils'; // Import from mockutils
 
@@ -23,13 +23,12 @@ describe("Testing the Functionality of Language Selector", () => {
         expect(screen.queryByTestId("Language-Selector-DropDown-Item-en")).not.toBeInTheDocument();
     });
 
-    // test('check if language changes on selection', () => {
-    //     renderWithProvider(<LanguageSelector />);
-    //     const button = screen.getByTestId("Language-Selector-Button");
-    //     fireEvent.mouseDown(button);
-    //     const dropdownItem = screen.getByTestId("Language-Selector-DropDown-Item-fr");
-    //     fireEvent.mouseDown(dropdownItem);
-    //     const selectedLanguage = screen.getByTestId("Language-Selector-Selected-DropDown-fr");
-    //     expect(selectedLanguage).toHaveTextContent("Français");
-    // });
+    test('Check if language changes on selection', () => {
+        renderWithProvider(<LanguageSelector />);
+        const button = screen.getByTestId("Language-Selector-Button");
+        fireEvent.mouseDown(button); // open dropdown
+        const dropdownItem = screen.getByTestId("Language-Selector-DropDown-Item-fr");
+        fireEvent.mouseDown(within(dropdownItem).getByRole("button")); // click the actual <button> inside the <li>
+        expect(screen.getByTestId("Language-Selector-Button")).toHaveTextContent("Français");
+    });
 });

--- a/inji-web/src/components/Common/LanguageSelector.tsx
+++ b/inji-web/src/components/Common/LanguageSelector.tsx
@@ -27,7 +27,13 @@ export const LanguageSelector: React.FC<{ "data-testid"?: string }> = ({ "data-t
 
     return <div className={"flex flex-row justify-center items-center"}
                 data-testid={testId ?? "LanguageSelector-Outer-Div"} 
-                onBlur={()=>setIsOpen(false)}
+                onBlur={(e)=>{
+                    // relatedTarget = where focus is going. If it's still inside this
+                    // component, don't close — only close when focus truly leaves.
+                    if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+                        setIsOpen(false);
+                    }
+                }}
                 tabIndex={0}
                 role="button">
         


### PR DESCRIPTION
 ## What does this PR do?
  Fixes a bug where the language selector required two clicks to reopen
  immediately after a language was changed. The first click appeared dead
  and only the second click opened the dropdown.

  **Root cause:** the selector's outer container is focusable (`tabIndex=0`)
  and closes the menu on `blur`. After a language change, focus lands on
  that container. The next click then moved focus to the toggle button,
  which fired the container's `onBlur` and instantly re-closed the menu —
  cancelling out the open. Since `onBlur` runs after `onMouseDown`, the
  close won, so the first click did nothing.

  **Fix:** guard the `onBlur` so it closes the menu only when focus leaves
  the component entirely (`!e.currentTarget.contains(e.relatedTarget)`),
  instead of on any internal focus shift.

  ## Related Issue
  fixes #623

  ## Type of Change
 fix - bug fix

  ## How to test
  1. Open the app and change the language once.
  2. Immediately click the language selector again.
  3. The dropdown should open on the **first** click (previously needed two).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed language selector dropdown closing prematurely when focus moves between dropdown menu elements, improving usability during language selection.

* **Tests**
  * Enhanced test coverage for language selection functionality with improved test implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->