### PR TITLE
fix(header): hide default profile initial when user is not logged in

### DIFF
--- a/inji-web/src/__tests__/components/LoginSessionStatusChecker.test.tsx
+++ b/inji-web/src/__tests__/components/LoginSessionStatusChecker.test.tsx
@@ -169,6 +169,19 @@ describe('LoginSessionStatusChecker', () => {
         });
     })
 
+    test("should clear loading and validate status after profile fetch fails on root", async () => {
+        (useLocation as jest.Mock).mockReturnValue({pathname: ROUTES.ROOT});
+        (AppStorage.getItem as jest.Mock).mockReturnValue(null);
+        mockFetchUserProfile.mockRejectedValue(new Error("Fetch failed"));
+
+        render(<LoginSessionStatusChecker/>);
+
+        await waitFor(() => {
+            expect(mockRemoveUser).toHaveBeenCalled();
+        });
+        expect(mockNavigate).not.toHaveBeenCalled();
+    })
+
     test.each([KEYS.USER, KEYS.WALLET_ID])("should recheck on storage change of %s key", async (storageKey) => {
         (useLocation as jest.Mock).mockReturnValue({pathname: ROUTES.USER_CREDENTIALS});
         const mockStorageEvent = new StorageEvent('storage', {

--- a/inji-web/src/__tests__/components/User/Header.test.tsx
+++ b/inji-web/src/__tests__/components/User/Header.test.tsx
@@ -174,4 +174,57 @@ describe('Header', () => {
 
         mockUseApi.fetchData.mockRestore();
     });
+
+    it('does not render profile details or default "U" when user is not logged in', () => {
+        (useUser as jest.Mock).mockReturnValue({
+            user: null,
+            removeUser: mockRemoveUser,
+            isLoading: false,
+        });
+
+        render(<Header headerRef={mockHeaderRef} headerHeight={50} />);
+
+        expect(screen.queryByTestId('profile-details')).not.toBeInTheDocument();
+        expect(screen.queryByText('U')).not.toBeInTheDocument();
+    });
+
+    it('shows profile skeleton while user profile is loading', () => {
+        (useUser as jest.Mock).mockReturnValue({
+            user: null,
+            removeUser: mockRemoveUser,
+            isLoading: true,
+        });
+
+        render(<Header headerRef={mockHeaderRef} headerHeight={50} />);
+
+        expect(screen.getByTestId('profile-details')).toBeInTheDocument();
+        expect(screen.queryByText('U')).not.toBeInTheDocument();
+    });
+
+    it('renders default "U" when displayName is missing for a logged-in user', () => {
+        (useUser as jest.Mock).mockReturnValue({
+            user: {...userProfile, displayName: undefined, profilePictureUrl: undefined},
+            removeUser: mockRemoveUser,
+            isLoading: false,
+        });
+
+        render(<Header headerRef={mockHeaderRef} headerHeight={50} />);
+
+        expect(screen.getByTestId('profile-details')).toBeInTheDocument();
+        expect(screen.getByText('U')).toBeInTheDocument();
+        expect(screen.queryByText('John Doe')).not.toBeInTheDocument();
+    });
+
+    it('renders profile initial from displayName when available', () => {
+        (useUser as jest.Mock).mockReturnValue({
+            user: {...userProfile, profilePictureUrl: undefined},
+            removeUser: mockRemoveUser,
+            isLoading: false,
+        });
+
+        render(<Header headerRef={mockHeaderRef} headerHeight={50} />);
+
+        expect(screen.getByText('J')).toBeInTheDocument();
+        expect(screen.getByText('John Doe')).toBeInTheDocument();
+    });
 });

--- a/inji-web/src/components/Common/LoginSessionStatusChecker.ts
+++ b/inji-web/src/components/Common/LoginSessionStatusChecker.ts
@@ -80,12 +80,13 @@ const LoginSessionStatusChecker = () => {
         try {
             setIsLoading(true)
             await fetchUserProfile();
-            setIsLoading(false)
         } catch (error) {
             console.error('Error fetching user profile:', error);
             if (isLoginProtectedRoute(location.pathname)) {
                 redirectToLogin();
             }
+        } finally {
+            setIsLoading(false)
         }
     }, [redirectToLogin, fetchUserProfile, location.pathname]);
 

--- a/inji-web/src/components/User/Header.tsx
+++ b/inji-web/src/components/User/Header.tsx
@@ -144,9 +144,13 @@ export const Header: React.FC<UserHeaderProps> = ({
                 <InfoFieldSkeleton width="w-24" height="h-2" />
               </div>
             );
-          }
-        
-          return (
+        }
+
+        if (!user) {
+            return null;
+        }
+
+        return (
             <div className="flex gap-2 items-center">
               <div
                 className={`aspect-square w-12 rounded-full bg-iw-avatarPlaceholder overflow-hidden flex items-center justify-center text-iw-avatarText font-medium text-lg ${
@@ -164,9 +168,11 @@ export const Header: React.FC<UserHeaderProps> = ({
                   getProfileInitials(displayName)
                 )}
               </div>
-              <span className="font-semibold text-gray-800">
-                {convertStringIntoPascalCase(displayName)}
-              </span>
+              {displayName && (
+                <span className="font-semibold text-gray-800">
+                  {convertStringIntoPascalCase(displayName)}
+                </span>
+              )}
             </div>
           );
         };
@@ -237,6 +243,7 @@ export const Header: React.FC<UserHeaderProps> = ({
                 <div className="flex items-center space-x-6">
                     <LanguageSelector />
 
+                    {(isLoading || user) && (
                     <div
                         data-testid="profile-details"
                         className="hidden sm:block relative"
@@ -244,7 +251,7 @@ export const Header: React.FC<UserHeaderProps> = ({
                     >
                         <div className="flex items-center space-x-2">
                             {getUserProfileIconWithName()}
-                            {!isLoading && !disableProfileDropdown && (
+                            {!isLoading && user && !disableProfileDropdown && (
                                 <div
                                 className="relative inline-block cursor-pointer"
                                 onClick={toggleProfileDropdown}
@@ -274,13 +281,14 @@ export const Header: React.FC<UserHeaderProps> = ({
                             </div>
                         )}
                     </div>
+                    )}
                 </div>
             </div>
             <div
                 data-testid="hamburger-menu-dropdown"
                 className="block sm:hidden w-full"
             >
-                {isHamburgerMenuOpen && (
+                {isHamburgerMenuOpen && (isLoading || user) && (
                     <div
                         style={{marginTop: headerHeight}}
                         className="absolute top-1 bg-white shadow-iw-hamburger-dropdown p-2 w-full"
@@ -289,7 +297,7 @@ export const Header: React.FC<UserHeaderProps> = ({
                             <div className="flex items-center px-4 py-2">
                                 {getUserProfileIconWithName()}
                             </div>
-                            {!disableProfileDropdown && dropdownItems.map((item, index) => (
+                            {!disableProfileDropdown && user && dropdownItems.map((item, index) => (
                                 <React.Fragment key={item.key}>
                                     <div
                                         className={`px-4 py-2 text-sm ${item.textColor} hover:bg-gray-100 cursor-pointer font-medium`}


### PR DESCRIPTION
closes #620

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved profile header behavior when account information is unavailable, preventing empty profile areas from appearing.
  - Profile details now display only when account data is available or still loading.
  - Improved loading-state handling during session checks to ensure the interface finishes loading even when profile retrieval fails.
  - Users on protected pages are still redirected to login when their session cannot be verified.
  - Mobile profile menus now appear only when appropriate account information is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->