### PR TITLE
fix(stored-cards): update localized VC names on language change

### DIFF
--- a/inji-web/src/__tests__/components/VC/VCCardView.test.tsx
+++ b/inji-web/src/__tests__/components/VC/VCCardView.test.tsx
@@ -342,6 +342,56 @@ describe('VCCardView Component', () => {
         expect(mockUseApi.fetchData).not.toHaveBeenCalled();
     });
 
+    it('should ignore in-flight preview response after preview is closed', async () => {
+        const actualRedux = jest.requireActual('react-redux');
+        const {useSelector} = require('react-redux') as {useSelector: jest.Mock};
+        useSelector.mockImplementation(actualRedux.useSelector);
+
+        mockApiResponse({
+            data: new Blob(['pdf-en'], {type: "application/pdf"}),
+            headers: {"Content-Disposition": 'attachment; filename="credential.pdf"'}
+        });
+
+        let resolveLanguagePreview: (value: unknown) => void;
+        const languagePreviewPromise = new Promise((resolve) => {
+            resolveLanguagePreview = resolve;
+        });
+
+        reduxStore.dispatch(storeLanguage('en'));
+        renderWithProvider(
+            <VCCardView
+                refreshCredentials={refreshCredentialsMock}
+                credential={mockCredential}
+            />
+        );
+
+        fireEvent.click(screen.getByTestId("vc-card-view"));
+        await screen.findByTestId("vc-detail-view");
+
+        mockUseApi.fetchData.mockReturnValueOnce(languagePreviewPromise);
+        reduxStore.dispatch(storeLanguage('fr'));
+
+        await waitFor(() => {
+            expect(mockUseApi.fetchData).toHaveBeenCalledTimes(2);
+        });
+
+        fireEvent.click(screen.getByRole('button', {name: 'Close'}));
+        expect(screen.queryByTestId("vc-detail-view")).not.toBeInTheDocument();
+
+        resolveLanguagePreview!({
+            ok: () => true,
+            data: new Blob(['pdf-fr'], {type: "application/pdf"}),
+            status: 200,
+            error: null,
+            headers: {},
+            state: RequestStatus.DONE
+        });
+
+        await waitFor(() => {
+            expect(screen.queryByTestId("vc-detail-view")).not.toBeInTheDocument();
+        });
+    });
+
     it("should show error when download fails", async () => {
         mockApiResponse({state: RequestStatus.ERROR, status: 500})
 

--- a/inji-web/src/__tests__/components/VC/VCCardView.test.tsx
+++ b/inji-web/src/__tests__/components/VC/VCCardView.test.tsx
@@ -14,6 +14,8 @@ import {KEYS, RequestStatus} from "../../../utils/constants";
 import {mockVerifiableCredentials} from "../../../test-utils/mockObjects";
 import {mockApiResponse, mockUseApi} from "../../../test-utils/setupUseApiMock";
 import {api} from "../../../utils/api";
+import {reduxStore} from "../../../redux/reduxStore";
+import {storeLanguage} from "../../../redux/reducers/commonReducer";
 
 jest.mock('react-toastify', () => {
     return {
@@ -40,6 +42,9 @@ jest.mock("../../../components/VC/VCDetailView", () => ({
         onDownload: () => Promise<void>,
         credential: WalletCredential
     }) => {
+        if (!previewContent) {
+            return null;
+        }
         const content = "Name:Simon";
         return (<div data-testid="vc-detail-view">
             <title>{credential.credentialTypeDisplayName}</title>
@@ -78,6 +83,7 @@ describe('VCCardView Component', () => {
                 language: 'en',
             },
         });
+        reduxStore.dispatch(storeLanguage('en'));
 
         localStorageMock = mockLocalStorage();
         localStorageMock.setItem(KEYS.WALLET_ID, "faa0e18f-0935-4fab-8ab3-0c546c0ca714")
@@ -274,6 +280,67 @@ describe('VCCardView Component', () => {
             expect(screen.getByText("Name:Simon")).toBeInTheDocument()
         })
     })
+
+    it('should refetch preview with updated Accept-Language when language changes while preview is open', async () => {
+        const actualRedux = jest.requireActual('react-redux');
+        const {useSelector} = require('react-redux') as {useSelector: jest.Mock};
+        useSelector.mockImplementation(actualRedux.useSelector);
+
+        mockApiResponse({
+            data: new Blob(['pdf-en'], {type: "application/pdf"}),
+            headers: {"Content-Disposition": 'attachment; filename="credential.pdf"'}
+        });
+        mockApiResponse({
+            data: new Blob(['pdf-fr'], {type: "application/pdf"}),
+            headers: {"Content-Disposition": 'attachment; filename="credential.pdf"'}
+        });
+
+        reduxStore.dispatch(storeLanguage('en'));
+
+        renderWithProvider(
+            <VCCardView
+                refreshCredentials={refreshCredentialsMock}
+                credential={mockCredential}
+            />
+        );
+
+        fireEvent.click(screen.getByTestId("vc-card-view"));
+        await screen.findByTestId("vc-detail-view");
+        expect(mockUseApi.fetchData).toHaveBeenCalledTimes(1);
+
+        reduxStore.dispatch(storeLanguage('fr'));
+
+        await waitFor(() => {
+            expect(mockUseApi.fetchData).toHaveBeenCalledTimes(2);
+        });
+        expect(mockUseApi.fetchData).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+                apiConfig: api.fetchWalletCredentialPreview,
+                headers: expect.objectContaining({
+                    "Accept-Language": "fr",
+                }),
+            })
+        );
+    });
+
+    it('should not refetch preview when language changes if preview is closed', () => {
+        const actualRedux = jest.requireActual('react-redux');
+        const {useSelector} = require('react-redux') as {useSelector: jest.Mock};
+        useSelector.mockImplementation(actualRedux.useSelector);
+
+        reduxStore.dispatch(storeLanguage('en'));
+
+        renderWithProvider(
+            <VCCardView
+                refreshCredentials={refreshCredentialsMock}
+                credential={mockCredential}
+            />
+        );
+
+        reduxStore.dispatch(storeLanguage('fr'));
+
+        expect(mockUseApi.fetchData).not.toHaveBeenCalled();
+    });
 
     it("should show error when download fails", async () => {
         mockApiResponse({state: RequestStatus.ERROR, status: 500})

--- a/inji-web/src/__tests__/components/VC/__snapshots__/VCCardView.test.tsx.snap
+++ b/inji-web/src/__tests__/components/VC/__snapshots__/VCCardView.test.tsx.snap
@@ -9,22 +9,6 @@ exports[`VCCardView Component should match snapshot 1`] = `
     tabindex="0"
   >
     <div
-      data-testid="vc-detail-view"
-    >
-      <title>
-        Drivers License
-      </title>
-      <div>
-        Name:Simon
-      </div>
-      <button>
-        Close
-      </button>
-      <button>
-        download
-      </button>
-    </div>
-    <div
       class="flex items-center gap-6 sm:gap-4 min-w-0 flex-1 overflow-hidden"
     >
       <img

--- a/inji-web/src/__tests__/pages/User/StoredCardsPage.test.tsx
+++ b/inji-web/src/__tests__/pages/User/StoredCardsPage.test.tsx
@@ -12,6 +12,8 @@ import {KEYS, RequestStatus} from "../../../utils/constants";
 import React from "react";
 import {mockApiResponse, mockApiResponseSequence, mockUseApi} from "../../../test-utils/setupUseApiMock";
 import {api} from "../../../utils/api";
+import {reduxStore} from "../../../redux/reduxStore";
+import {storeLanguage} from "../../../redux/reducers/commonReducer";
 
 mockUseTranslation()
 mockApiObject()
@@ -38,6 +40,7 @@ describe('Testing of StoredCardsPage ->', () => {
 
         localStorageMock.setItem('selectedLanguage', 'en');
         localStorageMock.setItem(KEYS.WALLET_ID, "faa0e18f-0935-4fab-8ab3-0c546c0ca714")
+        reduxStore.dispatch(storeLanguage('en'));
     });
 
 
@@ -93,6 +96,38 @@ describe('Testing of StoredCardsPage ->', () => {
             expect(asFragment()).toMatchSnapshot();
         });
     })
+
+    it('should refetch credentials with updated Accept-Language when language changes', async () => {
+        mockApiResponseSequence([
+            {data: mockCredentials},
+            {
+                data: [{
+                    ...mockCredentials[0],
+                    credentialTypeDisplayName: 'Permis de conduire',
+                    issuerDisplayName: 'DMV FR',
+                }]
+            }
+        ]);
+
+        renderWithRouter(<StoredCardsPage/>);
+        await waitForLoaderDisappearance();
+
+        expect(screen.getByText('Drivers License')).toBeInTheDocument();
+
+        reduxStore.dispatch(storeLanguage('fr'));
+
+        await waitFor(() => {
+            expect(mockUseApi.fetchData).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    headers: expect.objectContaining({"Accept-Language": "fr"}),
+                    apiConfig: api.fetchWalletVCs
+                })
+            );
+        });
+
+        await waitForLoaderDisappearance();
+        expect(screen.getByText('Permis de conduire')).toBeInTheDocument();
+    });
 
     it('should navigate to home on nav back button click', () => {
         renderWithRouter(<StoredCardsPage/>);

--- a/inji-web/src/__tests__/pages/User/StoredCardsPage.test.tsx
+++ b/inji-web/src/__tests__/pages/User/StoredCardsPage.test.tsx
@@ -129,6 +129,75 @@ describe('Testing of StoredCardsPage ->', () => {
         expect(screen.getByText('Permis de conduire')).toBeInTheDocument();
     });
 
+    it('should ignore stale credentials response after a newer language request completes', async () => {
+        let resolveStaleRequest: (value: unknown) => void;
+        const staleRequestPromise = new Promise((resolve) => {
+            resolveStaleRequest = resolve;
+        });
+
+        mockUseApi.fetchData
+            .mockReturnValueOnce(staleRequestPromise)
+            .mockResolvedValueOnce({
+                ok: () => true,
+                data: [{
+                    ...mockCredentials[0],
+                    credentialTypeDisplayName: 'Permis de conduire',
+                    issuerDisplayName: 'DMV FR',
+                }],
+                status: 200,
+                error: null,
+                headers: {},
+                state: RequestStatus.DONE
+            });
+
+        renderWithRouter(<StoredCardsPage/>);
+        expect(screen.getByTestId('loader-credentials')).toBeInTheDocument();
+
+        reduxStore.dispatch(storeLanguage('fr'));
+        await waitForLoaderDisappearance();
+        expect(screen.getByText('Permis de conduire')).toBeInTheDocument();
+
+        resolveStaleRequest!({
+            ok: () => true,
+            data: mockCredentials,
+            status: 200,
+            error: null,
+            headers: {},
+            state: RequestStatus.DONE
+        });
+
+        await waitFor(() => {
+            expect(screen.getByText('Permis de conduire')).toBeInTheDocument();
+        });
+        expect(screen.queryByText('Drivers License')).not.toBeInTheDocument();
+    });
+
+    it('should clear previous error when a later language reload succeeds', async () => {
+        mockApiResponseSequence([
+            {
+                error: {response: {data: {errorMessage: 'Internal Server Error'}}},
+                status: 500,
+                state: RequestStatus.ERROR
+            },
+            {
+                data: mockCredentials
+            }
+        ]);
+
+        renderWithRouter(<StoredCardsPage/>);
+        await waitForLoaderDisappearance();
+
+        await waitFor(() => {
+            expect(screen.getByText('Server Error')).toBeInTheDocument();
+        });
+
+        reduxStore.dispatch(storeLanguage('fr'));
+        await waitForLoaderDisappearance();
+
+        expect(screen.queryByText('Server Error')).not.toBeInTheDocument();
+        expect(screen.getByText('Drivers License')).toBeInTheDocument();
+    });
+
     it('should navigate to home on nav back button click', () => {
         renderWithRouter(<StoredCardsPage/>);
 

--- a/inji-web/src/components/VC/VCCardView.tsx
+++ b/inji-web/src/components/VC/VCCardView.tsx
@@ -1,6 +1,6 @@
 import {ApiRequest, ApiResult, WalletCredential} from "../../types/data";
 import {VCStyles} from "./VCStyles";
-import React, {useEffect, useState} from "react";
+import React, {useEffect, useRef, useState} from "react";
 import {Clickable} from "../Common/Clickable";
 import {api} from "../../utils/api";
 import {downloadCredentialPDF} from "../../utils/misc";
@@ -26,6 +26,7 @@ export function VCCardView(props: Readonly<{
     const [error, setError] = useState<string>()
     const [previewContent, setPreviewContent] = useState<Blob>();
     const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false)
+    const isPreviewOpenRef = useRef(false);
     const {t} = useTranslation('StoredCards', {
         keyPrefix: "cardView"
     })
@@ -77,11 +78,19 @@ export function VCCardView(props: Readonly<{
             api.fetchWalletCredentialPreview,
             async (response) => {
                 const pdfContent: Blob = response.data;
+                isPreviewOpenRef.current = true;
                 setPreviewContent(pdfContent);
             },
             previewApi,
         );
     };
+
+    useEffect(() => {
+        if (!isPreviewOpenRef.current) {
+            return;
+        }
+        void preview();
+    }, [language]);
 
     const handleDownload = async (event: React.MouseEvent) => {
         event.stopPropagation();
@@ -127,6 +136,7 @@ export function VCCardView(props: Readonly<{
     };
 
     const clearPreview = () => {
+        isPreviewOpenRef.current = false;
         setPreviewContent(undefined);
     }
 

--- a/inji-web/src/components/VC/VCCardView.tsx
+++ b/inji-web/src/components/VC/VCCardView.tsx
@@ -27,6 +27,7 @@ export function VCCardView(props: Readonly<{
     const [previewContent, setPreviewContent] = useState<Blob>();
     const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false)
     const isPreviewOpenRef = useRef(false);
+    const previewRequestIdRef = useRef(0);
     const {t} = useTranslation('StoredCards', {
         keyPrefix: "cardView"
     })
@@ -51,7 +52,8 @@ export function VCCardView(props: Readonly<{
         apiConfig: ApiRequest,
         onSuccess: (response: ApiResult<any>) => Promise<void>,
         apiInstance: ReturnType<typeof useApi>,
-        errorType: string = "downloadError"
+        errorType: string = "downloadError",
+        isCurrent: () => boolean = () => true
     ) => {
         try {
             const response = await apiInstance.fetchData({
@@ -59,6 +61,10 @@ export function VCCardView(props: Readonly<{
                 headers: apiConfig.headers(language),
                 apiConfig: apiConfig,
             })
+
+            if (!isCurrent()) {
+                return;
+            }
 
             if (!response.ok()) {
                 console.error(`Failed to fetch request, got ${errorType} with response - `, response);
@@ -68,20 +74,32 @@ export function VCCardView(props: Readonly<{
 
             await onSuccess(response);
         } catch (error) {
+            if (!isCurrent()) {
+                return;
+            }
             console.error("API request failed:", error);
             setError(errorType);
         }
     };
 
+    const isCurrentPreviewRequest = (requestId: number) =>
+        requestId === previewRequestIdRef.current && isPreviewOpenRef.current;
+
     const preview = async () => {
+        const requestId = ++previewRequestIdRef.current;
+        isPreviewOpenRef.current = true;
+
         await executeCredentialApiRequest(
             api.fetchWalletCredentialPreview,
             async (response) => {
-                const pdfContent: Blob = response.data;
-                isPreviewOpenRef.current = true;
-                setPreviewContent(pdfContent);
+                if (!isCurrentPreviewRequest(requestId)) {
+                    return;
+                }
+                setPreviewContent(response.data);
             },
             previewApi,
+            "downloadError",
+            () => isCurrentPreviewRequest(requestId)
         );
     };
 
@@ -90,6 +108,7 @@ export function VCCardView(props: Readonly<{
             return;
         }
         void preview();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [language]);
 
     const handleDownload = async (event: React.MouseEvent) => {
@@ -137,6 +156,7 @@ export function VCCardView(props: Readonly<{
 
     const clearPreview = () => {
         isPreviewOpenRef.current = false;
+        previewRequestIdRef.current += 1;
         setPreviewContent(undefined);
     }
 

--- a/inji-web/src/pages/User/StoredCards/StoredCardsPage.tsx
+++ b/inji-web/src/pages/User/StoredCards/StoredCardsPage.tsx
@@ -1,4 +1,4 @@
-import React, {Fragment, useEffect, useState} from 'react';
+import React, {Fragment, useEffect, useRef, useState} from 'react';
 import {useTranslation} from 'react-i18next';
 import {useNavigate} from 'react-router-dom';
 import {NavBackArrowButton} from '../../../components/Common/Buttons/NavBackArrowButton';
@@ -31,9 +31,11 @@ export const StoredCardsPage: React.FC = () => {
     const [loading, setLoading] = useState(true);
     const language = useSelector((state: RootState) => state.common.language);
     const [error, setError] = useState<string>();
+    const credentialsRequestIdRef = useRef(0);
 
 
     const fetchWalletCredentials = async () => {
+        const requestId = ++credentialsRequestIdRef.current;
         setLoading(true)
         try {
             const fetchWalletCredentials = api.fetchWalletVCs;
@@ -43,10 +45,15 @@ export const StoredCardsPage: React.FC = () => {
                 apiConfig: fetchWalletCredentials
             })
 
+            if (requestId !== credentialsRequestIdRef.current) {
+                return;
+            }
+
             if (response.ok()) {
                 const responseData = response.data!;
                 setCredentials(responseData);
                 setFilteredCredentials(responseData)
+                setError(undefined);
             } else {
                 console.error("Error fetching credentials:", response.status, response.error,  !navigator.onLine);
                 if (response.error?.message === (NETWORK_ERROR_MESSAGE) &&  !navigator.onLine) {
@@ -81,10 +88,15 @@ export const StoredCardsPage: React.FC = () => {
                 }
             }
         } catch (error) {
+            if (requestId !== credentialsRequestIdRef.current) {
+                return;
+            }
             console.error("An unknown error occurred. Failed to fetch credentials:", error);
             setError("unknownError");
         } finally {
-            setLoading(false);
+            if (requestId === credentialsRequestIdRef.current) {
+                setLoading(false);
+            }
         }
     };
 

--- a/inji-web/src/pages/User/StoredCards/StoredCardsPage.tsx
+++ b/inji-web/src/pages/User/StoredCards/StoredCardsPage.tsx
@@ -91,7 +91,7 @@ export const StoredCardsPage: React.FC = () => {
     useEffect(() => {
         void fetchWalletCredentials();
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
+    }, [language]);
 
     const filterCredentials = (searchText: string) => {
         if (searchText === "") {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Credential previews now refresh automatically when the selected language changes while the preview is open.
  * Stored credentials are reloaded in the selected language, including translated credential details.

* **Bug Fixes**
  * Prevented unnecessary credential requests when a preview is closed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->